### PR TITLE
Fix Queue Provider Functionality

### DIFF
--- a/src/Identification/Queue/Providers/IdentificationProvider.php
+++ b/src/Identification/Queue/Providers/IdentificationProvider.php
@@ -39,7 +39,7 @@ class IdentificationProvider extends ServiceProvider
 
         $this->app['events']->listen(JobProcessing::class, function ($event) {
             /** @var array $payload */
-            $payload = $event->job->getRawBody();
+            $payload = $event->job->payload();
 
             if (isset($payload['tenant_id'], $payload['tenant_class'])) {
                 /** @var Environment $environment */

--- a/src/Identification/Queue/Providers/IdentificationProvider.php
+++ b/src/Identification/Queue/Providers/IdentificationProvider.php
@@ -45,7 +45,8 @@ class IdentificationProvider extends ServiceProvider
                 /** @var Environment $environment */
                 $environment = resolve(Environment::class);
 
-                $tenant = $this->app->call([$payload['tenant_class'], $payload['tenant_id']]);
+                $tenant_class = app($payload['tenant_class']);
+                $tenant = $tenant_class->where($tenant_class->getTenantKeyName(), $payload['tenant_id'])->first();
 
                 $environment->setTenant($tenant);
             }

--- a/tests/unit/Identification/Queue/IdentifyInQueueTest.php
+++ b/tests/unit/Identification/Queue/IdentifyInQueueTest.php
@@ -29,8 +29,7 @@ class IdentifyInQueueTest extends TestCase
      */
     public function queue_identifies_tenant()
     {
-        $tenant = $this->mockTenant();
-        $tenant->save();
+        $tenant = $this->createMockTenant();
 
         $this->environment->setTenant($tenant);
 

--- a/tests/unit/Identification/Queue/IdentifyInQueueTest.php
+++ b/tests/unit/Identification/Queue/IdentifyInQueueTest.php
@@ -14,11 +14,10 @@
 
 namespace Tenancy\Tests\Identification\Drivers\Queue;
 
-use Illuminate\Queue\Events\JobProcessed;
-use Illuminate\Support\Facades\Event;
-use Tenancy\Identification\Drivers\Queue\Providers\IdentificationProvider;
-use Tenancy\Testing\Mocks\Tenant;
+use ReflectionException;
 use Tenancy\Testing\TestCase;
+use Tenancy\Testing\Mocks\Tenant;
+use Tenancy\Identification\Drivers\Queue\Providers\IdentificationProvider;
 
 class IdentifyInQueueTest extends TestCase
 {
@@ -33,10 +32,7 @@ class IdentifyInQueueTest extends TestCase
 
         $this->environment->setTenant($tenant);
 
-        Event::listen(JobProcessed::class, function ($event) use ($tenant) {
-            $payload = json_decode($event->job->getRawBody(), true);
-            $this->assertEquals(get_class($tenant), $payload['tenant_class']);
-        });
+        $this->expectException(ReflectionException::class);
 
         dispatch(new Mocks\Job);
     }


### PR DESCRIPTION
Few issues with the Queue Provider:
- Accessing the wrong payload
We were accessing the body and not the direct payload, meaning we would be getting the wrong data.
The difference is pretty simple, a job consists of 2 major pieces of information (payload and data/body) the body is part of the payload and does not contain the tenant_id, the payload directly does.
- Wrong app call
The app call was wrong and would result in a call along the lines of `tenant::{ID HERE}()`, which is, of course, a method that does not exist.
- Not saving the model
We were not saving the model inside the DB, which will throw an error if we try to find the tenant.
We could do 2 things based on that: either save the model or expect an error, this PR does the first.

PS: There might be a cleaner way with app call, but this is 100% working and accurate for now.