### PR TITLE
Adjusted the name and class of AutoDeletion

### DIFF
--- a/src/Tenancy/Database/Listeners/AutoDeleting.php
+++ b/src/Tenancy/Database/Listeners/AutoDeleting.php
@@ -14,7 +14,7 @@
 
 namespace Tenancy\Database\Listeners;
 
-class AutoDeletion extends DatabaseMutation
+class AutoDeleting extends DatabaseMutation
 {
     public function handle($event): ?bool
     {


### PR DESCRIPTION
Renamed this as it's throwing errors, this name was specified in the ProvidesListeners class.
We might have to rename AutoCreation as well, that seems more consistent.