### PR TITLE
Add Database Auto Listeners Tests

### DIFF
--- a/tests/unit/Tenancy/Database/AutoListenerTest.php
+++ b/tests/unit/Tenancy/Database/AutoListenerTest.php
@@ -72,6 +72,4 @@ class AutoListenerTest extends TestCase
 
         $this->assertTrue($this->events->dispatch(new Deleted($tenant))[0]);
     }
-
-
 }

--- a/tests/unit/Tenancy/Database/AutoListenerTest.php
+++ b/tests/unit/Tenancy/Database/AutoListenerTest.php
@@ -43,6 +43,9 @@ class AutoListenerTest extends TestCase
         $this->register_db_driver();
 
         $this->assertTrue($this->events->dispatch(new Created($tenant))[0]);
+
+        config(['tenancy.database.auto-create' => false]);
+        $this->assertNull($this->events->dispatch(new Created($tenant))[0]);
     }
 
     /**
@@ -57,6 +60,9 @@ class AutoListenerTest extends TestCase
         $this->register_db_driver();
 
         $this->assertTrue($this->events->dispatch(new Updated($tenant))[0]);
+
+        config(['tenancy.database.auto-update' => false]);
+        $this->assertNull($this->events->dispatch(new Updated($tenant))[0]);
     }
 
     /**
@@ -71,6 +77,9 @@ class AutoListenerTest extends TestCase
         $this->register_db_driver();
 
         $this->assertTrue($this->events->dispatch(new Deleted($tenant))[0]);
+
+        config(['tenancy.database.auto-delete' => false]);
+        $this->assertNull($this->events->dispatch(new Deleted($tenant))[0]);
     }
 
 

--- a/tests/unit/Tenancy/Database/AutoListenerTest.php
+++ b/tests/unit/Tenancy/Database/AutoListenerTest.php
@@ -22,7 +22,7 @@ use Tenancy\Tenant\Events\Deleted;
 
 class AutoListenerTest extends TestCase
 {
-    protected function register_db_driver()
+    protected function registerDatabaseDriver()
     {
         $this->events->forget(Resolving::class);
 
@@ -40,7 +40,7 @@ class AutoListenerTest extends TestCase
 
         $this->assertNull($this->events->dispatch(new Created($tenant))[0]);
 
-        $this->register_db_driver();
+        $this->registerDatabaseDriver();
 
         $this->assertTrue($this->events->dispatch(new Created($tenant))[0]);
 
@@ -57,7 +57,7 @@ class AutoListenerTest extends TestCase
 
         $this->assertNull($this->events->dispatch(new Updated($tenant))[0]);
 
-        $this->register_db_driver();
+        $this->registerDatabaseDriver();
 
         $this->assertTrue($this->events->dispatch(new Updated($tenant))[0]);
 
@@ -74,7 +74,7 @@ class AutoListenerTest extends TestCase
 
         $this->assertNull($this->events->dispatch(new Deleted($tenant))[0]);
 
-        $this->register_db_driver();
+        $this->registerDatabaseDriver();
 
         $this->assertTrue($this->events->dispatch(new Deleted($tenant))[0]);
 

--- a/tests/unit/Tenancy/Database/AutoListenerTest.php
+++ b/tests/unit/Tenancy/Database/AutoListenerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * (c) Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see http://laravel-tenancy.com
+ * @see https://github.com/tenancy
+ */
+
+namespace Tenancy\Tests\Database;
+
+use Tenancy\Testing\TestCase;
+use Tenancy\Database\Events\Resolving;
+use Tenancy\Tenant\Events\Created;
+use Tenancy\Tenant\Events\Updated;
+use Tenancy\Tenant\Events\Deleted;
+
+class AutoListenerTest extends TestCase
+{
+    protected function register_db_driver()
+    {
+        $this->events->forget(Resolving::class);
+
+        $this->events->listen(Resolving::class, function (Resolving $event) {
+            return new Mocks\NullDriver;
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function created_valid_responses()
+    {
+        $tenant = $this->mockTenant();
+
+        $this->assertNull($this->events->dispatch(new Created($tenant))[0]);
+
+        $this->register_db_driver();
+
+        $this->assertTrue($this->events->dispatch(new Created($tenant))[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function updated_valid_responses()
+    {
+        $tenant = $this->mockTenant();
+
+        $this->assertNull($this->events->dispatch(new Updated($tenant))[0]);
+
+        $this->register_db_driver();
+
+        $this->assertTrue($this->events->dispatch(new Updated($tenant))[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function deleted_valid_responses()
+    {
+        $tenant = $this->mockTenant();
+
+        $this->assertNull($this->events->dispatch(new Deleted($tenant))[0]);
+
+        $this->register_db_driver();
+
+        $this->assertTrue($this->events->dispatch(new Deleted($tenant))[0]);
+    }
+
+
+}

--- a/tests/unit/Tenancy/Database/Mocks/NullDriver.php
+++ b/tests/unit/Tenancy/Database/Mocks/NullDriver.php
@@ -49,6 +49,6 @@ class NullDriver implements ProvidesDatabase
     {
         $this->configure($tenant);
 
-        return false;
+        return true;
     }
 }


### PR DESCRIPTION
Simply checks their responses to normal situations with the null driver.