### PR TITLE
Fix config publishing

### DIFF
--- a/src/Tenancy/Identification/Support/DriverProvider.php
+++ b/src/Tenancy/Identification/Support/DriverProvider.php
@@ -55,7 +55,7 @@ abstract class DriverProvider extends EventServiceProvider
             $configPath = basename($config);
             $configName = basename($config, '.php');
 
-            $this->publishes([$config => config_path('tenancy\\' . $configPath)], [$configName, "tenancy"]);
+            $this->publishes([$config => config_path('tenancy' . DIRECTORY_SEPARATOR . $configPath)], [$configName, "tenancy"]);
 
             $this->mergeConfigFrom($config, 'tenancy.' . $configName);
         }


### PR DESCRIPTION
I was having an issue on Arch Linux where composer would try to push config files to: `/config/tenancy\identification-driver-http.php` which would cause the `/config/tenancy` folder to not be created; and the file not published.

Not sure if this is the best solution; but should be system agnostic from my understanding.
I believe that changing line 58 from `'tenancy\\'.` to `'tenancy/'` should also be system agnostic; but I do not have a windows computer to test on.