### PR TITLE
Fix ManagesSystemConnection check

### DIFF
--- a/src/Database/Mysql/Driver/Mysql.php
+++ b/src/Database/Mysql/Driver/Mysql.php
@@ -70,7 +70,7 @@ class Mysql implements ProvidesDatabase
     {
         $connection = null;
 
-        if (in_array(ManagesSystemConnection::class, class_implements($tenant))) {
+        if (in_array(ManagesSystemConnection::class, class_uses($tenant))) {
             $connection = $tenant->getManagingSystemConnection() ?? $connection;
         }
 


### PR DESCRIPTION
`ManagesSystemConnection` is a trait not an interface so I don't believe that it wold ever show up in `class_implements`, but will in `class_uses`.