### PR TITLE
Make the ManagesSystemConnection trait into a contract

### DIFF
--- a/src/Database/Mysql/Concerns/ManagesSystemConnection.php
+++ b/src/Database/Mysql/Concerns/ManagesSystemConnection.php
@@ -14,12 +14,12 @@
 
 namespace Tenancy\Database\Drivers\Mysql\Concerns;
 
-trait ManagesSystemConnection
+interface ManagesSystemConnection
 {
     /**
      * Allows overriding the system connection used for the tenant.
      *
      * @return null|string
      */
-    abstract public function getManagingSystemConnection(): ?string;
+    public function getManagingSystemConnection(): ?string;
 }


### PR DESCRIPTION
As per comments in #69.

Don't merge yet! Can someone double check that extending a model that implements an interface, will still be considered as a class that implemented in that class?