### PR TITLE
Fix CircleCI apt installs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
                   keys:
                       - composer-7.2-{{ checksum "composer.json" }}
             - run: apt-get -yqq update
-            - run: apt-get -yqq install git unzip zip libpq-dev mysql-client libpng-dev
+            - run: apt-get -yqq install git unzip zip libpq-dev default-mysql-client libpng-dev
             - run: docker-php-ext-install pdo_pgsql pdo_mysql gd
             - run: curl -sS https://getcomposer.org/installer | php
             - run: chmod +x composer.phar
@@ -37,7 +37,7 @@ jobs:
                   keys:
                       - composer-7.2-{{ checksum "composer.json" }}
             - run: apt-get -yqq update
-            - run: apt-get -yqq install git unzip zip libpq-dev mysql-client libpng-dev
+            - run: apt-get -yqq install git unzip zip libpq-dev default-mysql-client libpng-dev
             - run: docker-php-ext-install pdo_pgsql pdo_mysql gd
             - run: curl -sS https://getcomposer.org/installer | php
             - run: chmod +x composer.phar


### PR DESCRIPTION
MySQL Client is not working again, can fix this by installing the default-mysql-client