### PR TITLE
Set back default connection after migrations

### DIFF
--- a/src/Hooks/Migrations/Hooks/MigratesHook.php
+++ b/src/Hooks/Migrations/Hooks/MigratesHook.php
@@ -54,11 +54,16 @@ class MigratesHook extends ConfigurableHook
 
     public function fire(): void
     {
+        $db = resolve('db');
+        $default = $db->getDefaultConnection();
+
         $this->migrator->setConnection($this->connection);
 
         if (!$this->migrator->repositoryExists()) {
             $this->migrator->getRepository()->createRepository();
         }
         call_user_func([$this->migrator, $this->action], $this->migrator->paths());
+
+        $db->setDefaultConnection($default);
     }
 }

--- a/tests/unit/Hooks/Migrations/MigratesHookTest.php
+++ b/tests/unit/Hooks/Migrations/MigratesHookTest.php
@@ -33,11 +33,19 @@ class MigratesHookTest extends TestCase
      */
     protected $tenant;
 
+
+    /**
+     * @var string
+     */
+    protected $defaultConnection;
+
     public function afterSetUp()
     {
         $this->resolveTenant($this->tenant = $this->mockTenant());
 
         $this->migrateTenant(__DIR__.'/database/');
+
+        $this->defaultConnection = DB::getDefaultConnection();
 
         $this->events->dispatch(new Created($this->tenant));
     }
@@ -73,12 +81,21 @@ class MigratesHookTest extends TestCase
         config(['tenancy.database.auto-delete' => false]);
         $this->events->dispatch(new Deleted($this->tenant));
 
-//        Tenancy::getTenant();
-
         $this->assertFalse(
             DB::connection(Tenancy::getTenantConnectionName())
                 ->getSchemaBuilder()
                 ->hasTable('mocks')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function restores_default_connection()
+    {
+        $this->assertEquals(
+            $this->defaultConnection,
+            DB::getDefaultConnection()
         );
     }
 }

--- a/tests/unit/Hooks/Migrations/MigratesHookTest.php
+++ b/tests/unit/Hooks/Migrations/MigratesHookTest.php
@@ -33,7 +33,6 @@ class MigratesHookTest extends TestCase
      */
     protected $tenant;
 
-
     /**
      * @var string
      */

--- a/tests/unit/Hooks/Migrations/SeedsHookTest.php
+++ b/tests/unit/Hooks/Migrations/SeedsHookTest.php
@@ -32,12 +32,19 @@ class SeedsHookTest extends TestCase
      */
     protected $tenant;
 
+    /**
+     * @var string
+     */
+    protected $defaultConnection;
+
     public function afterSetUp()
     {
         $this->resolveTenant($this->tenant = $this->mockTenant());
 
         $this->migrateTenant(__DIR__.'/database/');
         $this->seedTenant(__DIR__.'/seeds/MockSeeder.php');
+
+        $this->defaultConnection = DB::getDefaultConnection();
 
         $this->events->dispatch(new Created($this->tenant));
     }
@@ -56,5 +63,16 @@ class SeedsHookTest extends TestCase
         );
 
         DB::disconnect(Tenancy::getTenantConnectionName());
+    }
+
+    /**
+     * @test
+     */
+    public function restores_default_connection()
+    {
+        $this->assertEquals(
+            $this->defaultConnection,
+            DB::getDefaultConnection()
+        );
     }
 }


### PR DESCRIPTION
Noticed this while creating tenants in the console (tinker).

Laravel's Migrator changes the entire DB's default connection to be the connection you set in the migrator, resulting in a change of the entire state of the application.

While this will recommend/force people to use migrations/database mutation on queue, I think we should still set back the default connection as it's cleaner and results in having the application back in the same state as we expect it to be.

Also an additional note:
We do this for seeders as well, I think we should either do it on both or on none.

# Note
At the moment of writing, tests fail due to the apt libraries not installing properly, look at PR #79 for that.