### PR TITLE
Set PHPCS rule to PSR2 instead of PSR12

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,5 +9,5 @@
 
     <arg value="np"/>
 
-    <rule ref="PSR12"/>
+    <rule ref="PSR2"/>
 </ruleset>


### PR DESCRIPTION
At this moment this is causing errors cause StyleCI will revert everything to PSR2.
For now, the quick fix would be to set PHPCS to use PSR2 instead of PSR12