### PR TITLE
Make all test namespaces consistent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
             "Tenancy\\Testing\\": "src/Testing",
             "Tenancy\\Tests\\": "tests/unit/Tenancy",
             "Tenancy\\Tests\\Affects\\": "tests/unit/Affects",
-            "Tenancy\\Tests\\Database\\Drivers\\": "tests/unit/Database",
+            "Tenancy\\Tests\\Database\\": "tests/unit/Database",
             "Tenancy\\Tests\\Hooks\\": "tests/unit/Hooks",
-            "Tenancy\\Tests\\Identification\\Drivers\\": "tests/unit/Identification"
+            "Tenancy\\Tests\\Identification\\": "tests/unit/Identification"
         }
     },
     "replace": {

--- a/tests/unit/Database/Mysql/ConfiguresMysqlTest.php
+++ b/tests/unit/Database/Mysql/ConfiguresMysqlTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @see https://github.com/tenancy
  */
 
-namespace Tenancy\Tests\Database;
+namespace Tenancy\Tests\Database\Mysql;
 
 use Tenancy\Database\Drivers\Mysql\Provider;
 use Tenancy\Database\Events\Drivers\Configuring;

--- a/tests/unit/Database/Sqlite/SqliteDriverTest.php
+++ b/tests/unit/Database/Sqlite/SqliteDriverTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @see https://github.com/tenancy
  */
 
-namespace Tenancy\Tests\Database;
+namespace Tenancy\Tests\Database\Sqlite;
 
 use Illuminate\Database\Connection;
 use Illuminate\Database\DatabaseManager;

--- a/tests/unit/Hooks/Migrations/ConfiguresMigrationsTest.php
+++ b/tests/unit/Hooks/Migrations/ConfiguresMigrationsTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @see https://github.com/tenancy
  */
 
-namespace Tenancy\Tests\Affects\Migrations;
+namespace Tenancy\Tests\Hooks\Migrations;
 
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;

--- a/tests/unit/Hooks/Migrations/MigratesHookTest.php
+++ b/tests/unit/Hooks/Migrations/MigratesHookTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @see https://github.com/tenancy
  */
 
-namespace Tenancy\Tests\Affects\Migrations;
+namespace Tenancy\Tests\Hooks\Migrations;
 
 use Illuminate\Support\Facades\DB;
 use Tenancy\Database\Drivers\Sqlite\Provider as DatabaseProvider;

--- a/tests/unit/Hooks/Migrations/SeedsHookTest.php
+++ b/tests/unit/Hooks/Migrations/SeedsHookTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @see https://github.com/tenancy
  */
 
-namespace Tenancy\Tests\Affects\Migrations;
+namespace Tenancy\Tests\Hooks\Migrations;
 
 use Illuminate\Support\Facades\DB;
 use Tenancy\Database\Drivers\Sqlite\Provider as DatabaseProvider;

--- a/tests/unit/Identification/Console/IdentifyByConsoleTest.php
+++ b/tests/unit/Identification/Console/IdentifyByConsoleTest.php
@@ -14,13 +14,13 @@ declare(strict_types=1);
  * @see https://github.com/tenancy
  */
 
-namespace Tenancy\Tests\Identification\Drivers\Console;
+namespace Tenancy\Tests\Identification\Console;
 
 use Illuminate\Contracts\Console\Kernel;
 use Tenancy\Identification\Contracts\ResolvesTenants;
 use Tenancy\Identification\Drivers\Console\Providers\IdentificationProvider;
 use Tenancy\Testing\TestCase;
-use Tenancy\Tests\Identification\Drivers\Console\Mocks\Tenant;
+use Tenancy\Tests\Identification\Console\Mocks\Tenant;
 
 class IdentifyByConsoleTest extends TestCase
 {

--- a/tests/unit/Identification/Console/Mocks/Tenant.php
+++ b/tests/unit/Identification/Console/Mocks/Tenant.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @see https://github.com/tenancy
  */
 
-namespace Tenancy\Tests\Identification\Drivers\Console\Mocks;
+namespace Tenancy\Tests\Identification\Console\Mocks;
 
 use Symfony\Component\Console\Input\InputInterface;
 use Tenancy\Identification\Contracts\Tenant as Contract;

--- a/tests/unit/Identification/Console/Mocks/factories/TenantFactory.php
+++ b/tests/unit/Identification/Console/Mocks/factories/TenantFactory.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  */
 
 use Faker\Generator as Faker;
-use Tenancy\Tests\Identification\Drivers\Console\Mocks\Tenant;
+use Tenancy\Tests\Identification\Console\Mocks\Tenant;
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/unit/Identification/Environment/IdentifyByEnvironmentTest.php
+++ b/tests/unit/Identification/Environment/IdentifyByEnvironmentTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @see https://github.com/tenancy
  */
 
-namespace Tenancy\Tests\Identification\Drivers\Http;
+namespace Tenancy\Tests\Identification\Http;
 
 use Dotenv\Environment\Adapter\EnvConstAdapter;
 use Dotenv\Environment\Adapter\ServerConstAdapter;
@@ -22,7 +22,7 @@ use Dotenv\Environment\DotenvFactory;
 use Tenancy\Identification\Contracts\ResolvesTenants;
 use Tenancy\Identification\Drivers\Environment\Providers\IdentificationProvider;
 use Tenancy\Testing\TestCase;
-use Tenancy\Tests\Identification\Drivers\Environment\Mocks\Tenant;
+use Tenancy\Tests\Identification\Environment\Mocks\Tenant;
 
 class IdentifyByEnvironmentTest extends TestCase
 {

--- a/tests/unit/Identification/Environment/Mocks/Tenant.php
+++ b/tests/unit/Identification/Environment/Mocks/Tenant.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @see https://github.com/tenancy
  */
 
-namespace Tenancy\Tests\Identification\Drivers\Environment\Mocks;
+namespace Tenancy\Tests\Identification\Environment\Mocks;
 
 use Tenancy\Identification\Contracts\Tenant as Contract;
 use Tenancy\Identification\Drivers\Environment\Contracts\IdentifiesByEnvironment;

--- a/tests/unit/Identification/Environment/Mocks/factories/TenantFactory.php
+++ b/tests/unit/Identification/Environment/Mocks/factories/TenantFactory.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  */
 
 use Faker\Generator as Faker;
-use Tenancy\Tests\Identification\Drivers\Environment\Mocks\Tenant;
+use Tenancy\Tests\Identification\Environment\Mocks\Tenant;
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/unit/Identification/Http/IdentifyByHttpTest.php
+++ b/tests/unit/Identification/Http/IdentifyByHttpTest.php
@@ -14,13 +14,13 @@ declare(strict_types=1);
  * @see https://github.com/tenancy
  */
 
-namespace Tenancy\Tests\Identification\Drivers\Http;
+namespace Tenancy\Tests\Identification\Http;
 
 use Illuminate\Database\Schema\Blueprint;
 use Tenancy\Identification\Contracts\ResolvesTenants;
 use Tenancy\Identification\Drivers\Http\Providers\IdentificationProvider;
 use Tenancy\Testing\TestCase;
-use Tenancy\Tests\Identification\Drivers\Http\Mocks\Hostname;
+use Tenancy\Tests\Identification\Http\Mocks\Hostname;
 
 class IdentifyByHttpTest extends TestCase
 {

--- a/tests/unit/Identification/Http/Middleware/EagerIdentificationTest.php
+++ b/tests/unit/Identification/Http/Middleware/EagerIdentificationTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @see https://github.com/tenancy
  */
 
-namespace Tenancy\Tests\Identification\Drivers\Http\Middleware;
+namespace Tenancy\Tests\Identification\Http\Middleware;
 
 use Illuminate\Http\Request;
 use Tenancy\Identification\Drivers\Http\Middleware\EagerIdentification;

--- a/tests/unit/Identification/Http/Mocks/Hostname.php
+++ b/tests/unit/Identification/Http/Mocks/Hostname.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @see https://github.com/tenancy
  */
 
-namespace Tenancy\Tests\Identification\Drivers\Http\Mocks;
+namespace Tenancy\Tests\Identification\Http\Mocks;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;

--- a/tests/unit/Identification/Http/Mocks/factories/HostnameFactory.php
+++ b/tests/unit/Identification/Http/Mocks/factories/HostnameFactory.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  */
 
 use Faker\Generator as Faker;
-use Tenancy\Tests\Identification\Drivers\Http\Mocks\Hostname;
+use Tenancy\Tests\Identification\Http\Mocks\Hostname;
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/unit/Identification/Queue/IdentifyInQueueTest.php
+++ b/tests/unit/Identification/Queue/IdentifyInQueueTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @see https://github.com/tenancy
  */
 
-namespace Tenancy\Tests\Identification\Drivers\Queue;
+namespace Tenancy\Tests\Identification\Queue;
 
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Support\Facades\Event;

--- a/tests/unit/Identification/Queue/Mocks/Job.php
+++ b/tests/unit/Identification/Queue/Mocks/Job.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @see https://github.com/tenancy
  */
 
-namespace Tenancy\Tests\Identification\Drivers\Queue\Mocks;
+namespace Tenancy\Tests\Identification\Queue\Mocks;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;


### PR DESCRIPTION
We had some test namespaces prefixed with "Drivers" before the driver name. We decided to get rid of this.

Made these namespaces consistent:
- Tests\Database
- Tests\Identification
- Tests\Hooks

They should all follow the current folder structure now.