### PR TITLE
DB Drivers Update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,8 @@ jobs:
     "php-7.2":
         docker:
             - image: php:7.2
+              environment: *environment
             - *mysql
-            environment: *environment
         working_directory: ~/repo
         steps:
             - checkout
@@ -55,8 +55,8 @@ jobs:
     "php-7.3":
         docker:
             - image: php:7.3
+              environment: *environment
             - *mysql
-            environment: *environment
         working_directory: ~/repo
         steps:
             - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,30 @@
 version: 2
 
+references:
+    mysql_environment: &mysql_environment
+        - MYSQL_DATABASE: testing
+        - MYSQL_USER: testing
+        - MYSQL_PASSWORD: testing
+        - MYSQL_ALLOW_EMPTY_PASSWORD: yes
+        - MYSQL_ROOT_HOST: "%"
+    mysql: &mysql
+        image: mysql:latest
+        entrypoint: ['/entrypoint.sh', '--default-authentication-plugin=mysql_native_password']
+        name: mysql
+        environment: *mysql_environment
+    environment: &environment
+        - TENANCY_DB: testing
+        - TENANCY_USERNAME: testing
+        - TENANCY_PASSWORD: testing
+        - TENANCY_HOST: mysql
+        - APP_KEY: deela5kinohw0haekoothahSh8eexach
+
 jobs:
     "php-7.2":
         docker:
             - image: php:7.2
+            - *mysql
+            environment: *environment
         working_directory: ~/repo
         steps:
             - checkout
@@ -22,6 +43,10 @@ jobs:
                   key: composer-7.2-{{ checksum "composer.json" }}
                   paths:
                       - vendor/
+            - run:
+                name: Wait for other docker instances to be up
+                command: sleep 10
+            - run: mysql --host=mysql -e "grant all privileges on *.* to 'testing'@'%' with grant option;"
             - run: ./vendor/bin/phpunit
             - persist_to_workspace:
                   root: ./
@@ -30,6 +55,8 @@ jobs:
     "php-7.3":
         docker:
             - image: php:7.3
+            - *mysql
+            environment: *environment
         working_directory: ~/repo
         steps:
             - checkout
@@ -48,6 +75,10 @@ jobs:
                   key: composer-7.3-{{ checksum "composer.json" }}
                   paths:
                       - vendor/
+            - run:
+                name: Wait for other docker instances to be up
+                command: sleep 10
+            - run: mysql --host=mysql -e "grant all privileges on *.* to 'testing'@'%' with grant option;"
             - run: ./vendor/bin/phpunit
 
     phpcs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,11 +94,17 @@ jobs:
     coverage:
         docker:
             - image: php:7.2
+              environment: *environment
+            - *mysql
         working_directory: ~/repo
         steps:
             - checkout
             - attach_workspace:
                   at: ./
+            - run: apt-get -yqq update
+            - run: apt-get -yqq install libpq-dev libpng-dev default-mysql-client
+            - run: docker-php-ext-install pdo_mysql pdo_pgsql
+            - run: mysql --host=mysql -e "grant all privileges on *.* to 'testing'@'%' with grant option;"
             - run: pecl install xdebug
             - run: docker-php-ext-enable xdebug
             - run: ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "license": "MIT",
     "require": {
         "laravel/framework": "5.8.*",
-        "psr/container": "^1.0.0"
+        "psr/container": "^1.0.0",
+        "doctrine/dbal": "^2.9"
     },
     "require-dev": {
         "fzaninotto/faker": "^1.7",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -32,5 +32,8 @@
         <env name="QUEUE_DRIVER" value="sync"/>
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
+        <env name="TENANCY_DB" value="testing"/>
+        <env name="TENANCY_USERNAME" value="testing"/>
+        <env name="TENANCY_PASSWORD" value="testing"/>
     </php>
 </phpunit>

--- a/src/Database/Mysql/Driver/Mysql.php
+++ b/src/Database/Mysql/Driver/Mysql.php
@@ -69,14 +69,13 @@ class Mysql implements ProvidesDatabase
 
         Tenancy::setTenant($tempTenant);
         $connection = Tenancy::getTenantConnection();
-        $tables = $connection->select('SHOW TABLES');
+        $tables = $connection->getDoctrineSchemaManager()->listTableNames();
+
         Tenancy::setTenant($originalTenant);
 
         $tableStatements = [];
         foreach ($tables as $table) {
-            foreach ($table as $key => $value) {
-                $tableStatements['table'.$value] = "RENAME TABLE `{$config['oldUsername']}`.{$value} TO `{$config['database']}`.{$value}";
-            }
+            $tableStatements['table'.$table] = "RENAME TABLE `{$config['oldUsername']}`.{$table} TO `{$config['database']}`.{$table}";
         }
         // Add database drop statement as last statement
         $tableStatements['delete_db'] = "DROP DATABASE `{$config['oldUsername']}`";

--- a/src/Database/Mysql/Driver/Mysql.php
+++ b/src/Database/Mysql/Driver/Mysql.php
@@ -71,8 +71,8 @@ class Mysql implements ProvidesDatabase
         $tables = $connection->select('SHOW TABLES');
 
         $tableStatements = [];
-        foreach($tables as $table){
-            foreach($table as $key => $value){
+        foreach ($tables as $table) {
+            foreach ($table as $key => $value) {
                 $tableStatements['table'.$value] = "RENAME TABLE `{$config['oldUsername']}`.{$value} TO `{$config['database']}`.{$value}";
             }
         }

--- a/src/Database/Mysql/Driver/Mysql.php
+++ b/src/Database/Mysql/Driver/Mysql.php
@@ -39,6 +39,10 @@ class Mysql implements ProvidesDatabase
     {
         $config = $this->configure($tenant);
 
+        if (isset($config['allowedHost'])) {
+            $config['host'] = $config['allowedHost'];
+        }
+
         return $this->process($tenant, [
             'user'     => "CREATE USER IF NOT EXISTS `{$config['username']}`@'{$config['host']}' IDENTIFIED BY '{$config['password']}'",
             'database' => "CREATE DATABASE `{$config['database']}`",
@@ -54,6 +58,10 @@ class Mysql implements ProvidesDatabase
             return false;
         }
 
+        if (isset($config['allowedHost'])) {
+            $config['host'] = $config['allowedHost'];
+        }
+
         return $this->process($tenant, [
             'user'     => "RENAME USER `{$config['oldUsername']}`@'{$config['host']}' TO `{$config['username']}`@'{$config['host']}'",
             'password' => "ALTER USER `{$config['username']}`@`{$config['host']}` IDENTIFIED BY '{$config['password']}'",
@@ -65,6 +73,10 @@ class Mysql implements ProvidesDatabase
     public function delete(Tenant $tenant): bool
     {
         $config = $this->configure($tenant);
+
+        if (isset($config['allowedHost'])) {
+            $config['host'] = $config['allowedHost'];
+        }
 
         return $this->process($tenant, [
             'user'     => "DROP USER `{$config['username']}`@'{$config['host']}'",

--- a/src/Database/Mysql/Driver/Mysql.php
+++ b/src/Database/Mysql/Driver/Mysql.php
@@ -16,14 +16,14 @@ declare(strict_types=1);
 
 namespace Tenancy\Database\Drivers\Mysql\Driver;
 
-use Tenancy\Facades\Tenancy;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Database\QueryException;
 use Illuminate\Database\ConnectionInterface;
-use Tenancy\Identification\Contracts\Tenant;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
 use Tenancy\Database\Contracts\ProvidesDatabase;
-use Tenancy\Database\Events\Drivers\Configuring;
 use Tenancy\Database\Drivers\Mysql\Concerns\ManagesSystemConnection;
+use Tenancy\Database\Events\Drivers\Configuring;
+use Tenancy\Facades\Tenancy;
+use Tenancy\Identification\Contracts\Tenant;
 
 class Mysql implements ProvidesDatabase
 {

--- a/src/Database/Mysql/Driver/Mysql.php
+++ b/src/Database/Mysql/Driver/Mysql.php
@@ -55,7 +55,7 @@ class Mysql implements ProvidesDatabase
         }
 
         return $this->process($tenant, [
-            'user' => "RENAME USER `{$config['oldUsername']}`@'{$config['host']}' TO `{$config['username']}`@'{$config['host']}'",
+            'user'     => "RENAME USER `{$config['oldUsername']}`@'{$config['host']}' TO `{$config['username']}`@'{$config['host']}'",
             'password' => "ALTER USER `{$config['username']}`@`{$config['host']}` IDENTIFIED BY '{$config['password']}'",
             'database' => "CREATE DATABASE `{$config['database']}`",
             'grant'    => "GRANT ALL ON `{$config['database']}`.* TO `{$config['username']}`@'{$config['host']}'",

--- a/src/Database/Mysql/Driver/Mysql.php
+++ b/src/Database/Mysql/Driver/Mysql.php
@@ -56,6 +56,9 @@ class Mysql implements ProvidesDatabase
 
         return $this->process($tenant, [
             'user' => "RENAME USER `{$config['oldUsername']}`@'{$config['host']}' TO `{$config['username']}`@'{$config['host']}'",
+            'password' => "ALTER USER `{$config['username']}`@`{$config['host']}` IDENTIFIED BY '{$config['password']}'",
+            'database' => "CREATE DATABASE `{$config['database']}`",
+            'grant'    => "GRANT ALL ON `{$config['database']}`.* TO `{$config['username']}`@'{$config['host']}'",
         ]);
     }
 

--- a/src/Database/Mysql/Driver/Mysql.php
+++ b/src/Database/Mysql/Driver/Mysql.php
@@ -77,8 +77,6 @@ class Mysql implements ProvidesDatabase
         foreach ($tables as $table) {
             $tableStatements['table'.$table] = "RENAME TABLE `{$config['oldUsername']}`.{$table} TO `{$config['database']}`.{$table}";
         }
-        // Add database drop statement as last statement
-        $tableStatements['delete_db'] = "DROP DATABASE `{$config['oldUsername']}`";
 
         $statements = array_merge([
             'user'     => "RENAME USER `{$config['oldUsername']}`@'{$config['host']}' TO `{$config['username']}`@'{$config['host']}'",
@@ -86,6 +84,9 @@ class Mysql implements ProvidesDatabase
             'database' => "CREATE DATABASE `{$config['database']}`",
             'grant'    => "GRANT ALL ON `{$config['database']}`.* TO `{$config['username']}`@'{$config['host']}'",
         ], $tableStatements);
+
+        // Add database drop statement as last statement
+        $tableStatements['delete_db'] = "DROP DATABASE `{$config['oldUsername']}`";
 
         return $this->process($tenant, $statements);
     }

--- a/src/Database/Mysql/Driver/Mysql.php
+++ b/src/Database/Mysql/Driver/Mysql.php
@@ -70,6 +70,7 @@ class Mysql implements ProvidesDatabase
         Tenancy::setTenant($tempTenant);
         $connection = Tenancy::getTenantConnection();
         $tables = $connection->select('SHOW TABLES');
+        Tenancy::setTenant($originalTenant);
 
         $tableStatements = [];
         foreach ($tables as $table) {
@@ -77,7 +78,6 @@ class Mysql implements ProvidesDatabase
                 $tableStatements['table'.$value] = "RENAME TABLE `{$config['oldUsername']}`.{$value} TO `{$config['database']}`.{$value}";
             }
         }
-
         // Add database drop statement as last statement
         $tableStatements['delete_db'] = "DROP DATABASE `{$config['oldUsername']}`";
 
@@ -87,8 +87,6 @@ class Mysql implements ProvidesDatabase
             'database' => "CREATE DATABASE `{$config['database']}`",
             'grant'    => "GRANT ALL ON `{$config['database']}`.* TO `{$config['username']}`@'{$config['host']}'",
         ], $tableStatements);
-
-        Tenancy::setTenant($originalTenant);
 
         return $this->process($tenant, $statements);
     }

--- a/src/Database/Mysql/Driver/Mysql.php
+++ b/src/Database/Mysql/Driver/Mysql.php
@@ -16,13 +16,14 @@ declare(strict_types=1);
 
 namespace Tenancy\Database\Drivers\Mysql\Driver;
 
-use Illuminate\Database\ConnectionInterface;
-use Illuminate\Database\QueryException;
+use Tenancy\Facades\Tenancy;
 use Illuminate\Support\Facades\DB;
-use Tenancy\Database\Contracts\ProvidesDatabase;
-use Tenancy\Database\Drivers\Mysql\Concerns\ManagesSystemConnection;
-use Tenancy\Database\Events\Drivers\Configuring;
+use Illuminate\Database\QueryException;
+use Illuminate\Database\ConnectionInterface;
 use Tenancy\Identification\Contracts\Tenant;
+use Tenancy\Database\Contracts\ProvidesDatabase;
+use Tenancy\Database\Events\Drivers\Configuring;
+use Tenancy\Database\Drivers\Mysql\Concerns\ManagesSystemConnection;
 
 class Mysql implements ProvidesDatabase
 {

--- a/src/Database/Sqlite/Driver/Sqlite.php
+++ b/src/Database/Sqlite/Driver/Sqlite.php
@@ -24,13 +24,7 @@ class Sqlite implements ProvidesDatabase
 {
     public function configure(Tenant $tenant): array
     {
-        if ($name = config('tenancy.db-driver-sqlite.use-connection')) {
-            return config("database.connections.$name");
-        }
-
-        $config = config('tenancy.db-driver-sqlite.preset', []);
-
-        $config['database'] = database_path($tenant->getTenantKey());
+        $config = [];
 
         event(new Configuring($tenant, $config, $this));
 

--- a/src/Database/Sqlite/Driver/Sqlite.php
+++ b/src/Database/Sqlite/Driver/Sqlite.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Tenancy\Database\Drivers\Sqlite\Driver;
 
 use Tenancy\Database\Contracts\ProvidesDatabase;
-use Tenancy\Database\Events\Drivers\Configuring;
+use Tenancy\Database\Events\Drivers as Events;
 use Tenancy\Identification\Contracts\Tenant;
 
 class Sqlite implements ProvidesDatabase
@@ -26,7 +26,7 @@ class Sqlite implements ProvidesDatabase
     {
         $config = [];
 
-        event(new Configuring($tenant, $config, $this));
+        event(new Events\Configuring($tenant, $config, $this));
 
         return $config;
     }
@@ -34,6 +34,8 @@ class Sqlite implements ProvidesDatabase
     public function create(Tenant $tenant): bool
     {
         $config = $this->configure($tenant);
+
+        event(new Events\Creating($tenant, $config, $this));
 
         return touch($config['database']);
     }
@@ -45,6 +47,8 @@ class Sqlite implements ProvidesDatabase
         $previous = $this->configure($original);
 
         $config = $this->configure($tenant);
+
+        event(new Events\Updating($tenant, $config, $this));
 
         if ($previous['database'] !== $config['database']) {
             return rename(
@@ -59,6 +63,8 @@ class Sqlite implements ProvidesDatabase
     public function delete(Tenant $tenant): bool
     {
         $config = $this->configure($tenant);
+
+        event(new Events\Deleting($tenant, $config, $this));
 
         return unlink($config['database']);
     }

--- a/src/Tenancy/Database/Events/Drivers/Configuring.php
+++ b/src/Tenancy/Database/Events/Drivers/Configuring.php
@@ -55,13 +55,16 @@ class Configuring
         return $this;
     }
 
-    public function useConfig(string $path)
+    public function useConfig(string $path, array $override = [])
     {
         if (!file_exists($path)) {
             throw new InvalidArgumentException("Cannot set up tenant connection configuration, file $path does not exist.");
         }
 
-        $this->configuration = include $path;
+        $this->configuration = array_merge(
+            include $path,
+            $override
+        );
 
         return $this;
     }

--- a/src/Tenancy/Database/Events/Drivers/Creating.php
+++ b/src/Tenancy/Database/Events/Drivers/Creating.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Laravel Tenancy & Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+
+namespace Tenancy\Database\Events\Drivers;
+
+use Tenancy\Database\Contracts\ProvidesDatabase;
+use Tenancy\Identification\Contracts\Tenant;
+
+class Creating
+{
+    /**
+     * @var Tenant
+     */
+    public $tenant;
+    /**
+     * @var array
+     */
+    public $configuration;
+    /**
+     * @var ProvidesDatabase
+     */
+    public $provider;
+
+    public function __construct(Tenant $tenant, array &$configuration, ProvidesDatabase $provider)
+    {
+        $this->tenant = $tenant;
+        $this->configuration = &$configuration;
+        $this->provider = $provider;
+    }
+}

--- a/src/Tenancy/Database/Events/Drivers/Deleting.php
+++ b/src/Tenancy/Database/Events/Drivers/Deleting.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Laravel Tenancy & Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+
+namespace Tenancy\Database\Events\Drivers;
+
+use Tenancy\Database\Contracts\ProvidesDatabase;
+use Tenancy\Identification\Contracts\Tenant;
+
+class Deleting
+{
+    /**
+     * @var Tenant
+     */
+    public $tenant;
+    /**
+     * @var array
+     */
+    public $configuration;
+    /**
+     * @var ProvidesDatabase
+     */
+    public $provider;
+
+    public function __construct(Tenant $tenant, array &$configuration, ProvidesDatabase $provider)
+    {
+        $this->tenant = $tenant;
+        $this->configuration = &$configuration;
+        $this->provider = $provider;
+    }
+}

--- a/src/Tenancy/Database/Events/Drivers/Updating.php
+++ b/src/Tenancy/Database/Events/Drivers/Updating.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Laravel Tenancy & Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+
+namespace Tenancy\Database\Events\Drivers;
+
+use Tenancy\Database\Contracts\ProvidesDatabase;
+use Tenancy\Identification\Contracts\Tenant;
+
+class Updating
+{
+    /**
+     * @var Tenant
+     */
+    public $tenant;
+    /**
+     * @var array
+     */
+    public $configuration;
+    /**
+     * @var ProvidesDatabase
+     */
+    public $provider;
+
+    public function __construct(Tenant $tenant, array &$configuration, ProvidesDatabase $provider)
+    {
+        $this->tenant = $tenant;
+        $this->configuration = &$configuration;
+        $this->provider = $provider;
+    }
+}

--- a/src/Testing/DatabaseDriverTestCase.php
+++ b/src/Testing/DatabaseDriverTestCase.php
@@ -16,20 +16,17 @@ declare(strict_types=1);
 
 namespace Tenancy\Testing;
 
-use PDO;
-use PDOException;
-use Tenancy\Tenant\Events;
-use Tenancy\Facades\Tenancy;
-use Tenancy\Testing\TestCase;
-use Tenancy\Testing\Mocks\Tenant;
 use Illuminate\Database\DatabaseManager;
+use Illuminate\Database\QueryException;
+use PDO;
+use Tenancy\Facades\Tenancy;
 use Tenancy\Identification\Contracts\ResolvesTenants;
 use Tenancy\Identification\Contracts\Tenant as TenantContract;
-use Illuminate\Database\QueryException;
+use Tenancy\Tenant\Events;
+use Tenancy\Testing\Mocks\Tenant;
 
 abstract class DatabaseDriverTestCase extends TestCase
 {
-
     protected $db;
 
     protected $tenant;
@@ -63,15 +60,17 @@ abstract class DatabaseDriverTestCase extends TestCase
         return $this->db->connection(Tenancy::getTenantConnectionName());
     }
 
-    protected function cleanDatabases(TenantContract $tenant = null){
+    protected function cleanDatabases(TenantContract $tenant = null)
+    {
         $this->db->purge(Tenancy::getTenantConnectionName());
-        if($tenant == null){
+        if ($tenant == null) {
             $tenant = $this->tenant;
         }
         $this->events->dispatch(new Events\Deleted($tenant));
     }
 
-    protected function registerModel(){
+    protected function registerModel()
+    {
         /** @var ResolvesTenants $resolver */
         $resolver = $this->app->make(ResolvesTenants::class);
         $resolver->addModel($this->tenantModel);

--- a/src/Testing/DatabaseDriverTestCase.php
+++ b/src/Testing/DatabaseDriverTestCase.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Laravel Tenancy & Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+
+namespace Tenancy\Testing;
+
+use PDO;
+use PDOException;
+use Tenancy\Tenant\Events;
+use Tenancy\Facades\Tenancy;
+use Tenancy\Testing\TestCase;
+use Tenancy\Testing\Mocks\Tenant;
+use Illuminate\Database\DatabaseManager;
+use Tenancy\Identification\Contracts\ResolvesTenants;
+use Tenancy\Identification\Contracts\Tenant as TenantContract;
+use Illuminate\Database\QueryException;
+
+abstract class DatabaseDriverTestCase extends TestCase
+{
+
+    protected $db;
+
+    protected $tenant;
+
+    protected $tenantModel = Tenant::class;
+
+    protected $exception = QueryException::class;
+
+    protected function afterSetUp()
+    {
+        $this->registerModel();
+
+        $this->db = resolve(DatabaseManager::class);
+
+        $this->tenant = factory($this->tenantModel)->create([
+            'id' => 1803,
+        ]);
+        $this->tenant->unguard();
+
+        $this->resolveTenant($this->tenant);
+
+        $this->registerDatabaseListener();
+    }
+
+    abstract protected function registerDatabaseListener();
+
+    protected function getTenantConnection()
+    {
+        Tenancy::getTenant();
+
+        return $this->db->connection(Tenancy::getTenantConnectionName());
+    }
+
+    protected function cleanDatabases(TenantContract $tenant = null){
+        $this->db->purge(Tenancy::getTenantConnectionName());
+        if($tenant == null){
+            $tenant = $this->tenant;
+        }
+        $this->events->dispatch(new Events\Deleted($tenant));
+    }
+
+    protected function registerModel(){
+        /** @var ResolvesTenants $resolver */
+        $resolver = $this->app->make(ResolvesTenants::class);
+        $resolver->addModel($this->tenantModel);
+    }
+
+    /**
+     * @test
+     */
+    public function runs_create()
+    {
+        $this->events->dispatch(new Events\Created($this->tenant));
+
+        $this->assertInstanceOf(
+            PDO::class,
+            $this->getTenantConnection()->getPdo()
+        );
+
+        $this->cleanDatabases();
+    }
+
+    /**
+     * @test
+     */
+    public function prevent_same_update()
+    {
+        $this->events->dispatch(new Events\Created($this->tenant));
+        $this->events->dispatch(new Events\Updated($this->tenant));
+
+        $this->assertInstanceOf(
+            PDO::class,
+            $this->getTenantConnection()->getPdo()
+        );
+
+        $this->cleanDatabases();
+    }
+
+    /**
+     * @test
+     */
+    public function runs_update()
+    {
+        $this->events->dispatch(new Events\Created($this->tenant));
+
+        $this->tenant->id = 1997;
+        $this->events->dispatch(new Events\Updated($this->tenant));
+
+        $this->assertInstanceOf(
+            PDO::class,
+            $this->getTenantConnection()->getPdo()
+        );
+
+        $this->cleanDatabases();
+    }
+
+    /**
+     * @test
+     */
+    public function runs_delete()
+    {
+        $this->events->dispatch(new Events\Created($this->tenant));
+        $this->events->dispatch(new Events\Deleted($this->tenant));
+
+        $this->expectException($this->exception);
+        $this->getTenantConnection()->getPdo();
+    }
+}

--- a/src/Testing/DatabaseDriverTestCase.php
+++ b/src/Testing/DatabaseDriverTestCase.php
@@ -63,9 +63,11 @@ abstract class DatabaseDriverTestCase extends TestCase
     protected function cleanDatabases(TenantContract $tenant = null)
     {
         $this->db->purge(Tenancy::getTenantConnectionName());
+
         if ($tenant == null) {
             $tenant = $this->tenant;
         }
+
         $this->events->dispatch(new Events\Deleted($tenant));
     }
 
@@ -131,6 +133,14 @@ abstract class DatabaseDriverTestCase extends TestCase
     public function runs_delete()
     {
         $this->events->dispatch(new Events\Created($this->tenant));
+
+        $this->assertInstanceOf(
+            PDO::class,
+            $this->getTenantConnection()->getPdo()
+        );
+
+        $this->db->purge(Tenancy::getTenantConnectionName());
+
         $this->events->dispatch(new Events\Deleted($this->tenant));
 
         $this->expectException($this->exception);

--- a/tests/unit/Database/DatabaseDriverTestCase.php
+++ b/tests/unit/Database/DatabaseDriverTestCase.php
@@ -16,16 +16,16 @@ declare(strict_types=1);
 
 namespace Tenancy\Tests\Database;
 
-use PDO;
-use Tenancy\Tenant\Events;
-use Tenancy\Facades\Tenancy;
-use Tenancy\Testing\TestCase;
-use Tenancy\Testing\Mocks\Tenant;
-use Tenancy\Hooks\Migrations\Provider;
-use Illuminate\Database\QueryException;
 use Illuminate\Database\DatabaseManager;
+use Illuminate\Database\QueryException;
+use PDO;
+use Tenancy\Facades\Tenancy;
+use Tenancy\Hooks\Migrations\Provider;
 use Tenancy\Identification\Contracts\ResolvesTenants;
 use Tenancy\Identification\Contracts\Tenant as TenantContract;
+use Tenancy\Tenant\Events;
+use Tenancy\Testing\Mocks\Tenant;
+use Tenancy\Testing\TestCase;
 
 abstract class DatabaseDriverTestCase extends TestCase
 {
@@ -135,7 +135,7 @@ abstract class DatabaseDriverTestCase extends TestCase
     public function runs_update_moves_tables()
     {
         $this->app->register(Provider::class);
-        $this->migrateTenant(__DIR__. DIRECTORY_SEPARATOR . 'migrations');
+        $this->migrateTenant(__DIR__.DIRECTORY_SEPARATOR.'migrations');
 
         $this->events->dispatch(new Events\Created($this->tenant));
 

--- a/tests/unit/Database/DatabaseDriverTestCase.php
+++ b/tests/unit/Database/DatabaseDriverTestCase.php
@@ -16,14 +16,15 @@ declare(strict_types=1);
 
 namespace Tenancy\Tests\Database;
 
-use Illuminate\Database\DatabaseManager;
-use Illuminate\Database\QueryException;
 use PDO;
+use Tenancy\Tenant\Events;
 use Tenancy\Facades\Tenancy;
+use Tenancy\Testing\TestCase;
+use Tenancy\Testing\Mocks\Tenant;
+use Illuminate\Database\QueryException;
+use Illuminate\Database\DatabaseManager;
 use Tenancy\Identification\Contracts\ResolvesTenants;
 use Tenancy\Identification\Contracts\Tenant as TenantContract;
-use Tenancy\Tenant\Events;
-use Tenancy\Testing\Mocks\Tenant;
 
 abstract class DatabaseDriverTestCase extends TestCase
 {

--- a/tests/unit/Database/DatabaseDriverTestCase.php
+++ b/tests/unit/Database/DatabaseDriverTestCase.php
@@ -16,15 +16,15 @@ declare(strict_types=1);
 
 namespace Tenancy\Tests\Database;
 
-use PDO;
-use Tenancy\Tenant\Events;
-use Tenancy\Facades\Tenancy;
-use Tenancy\Testing\TestCase;
-use Tenancy\Testing\Mocks\Tenant;
-use Illuminate\Database\QueryException;
 use Illuminate\Database\DatabaseManager;
+use Illuminate\Database\QueryException;
+use PDO;
+use Tenancy\Facades\Tenancy;
 use Tenancy\Identification\Contracts\ResolvesTenants;
 use Tenancy\Identification\Contracts\Tenant as TenantContract;
+use Tenancy\Tenant\Events;
+use Tenancy\Testing\Mocks\Tenant;
+use Tenancy\Testing\TestCase;
 
 abstract class DatabaseDriverTestCase extends TestCase
 {

--- a/tests/unit/Database/DatabaseDriverTestCase.php
+++ b/tests/unit/Database/DatabaseDriverTestCase.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @see https://github.com/tenancy
  */
 
-namespace Tenancy\Testing;
+namespace Tenancy\Tests\Database;
 
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\QueryException;

--- a/tests/unit/Database/DatabaseDriverTestCase.php
+++ b/tests/unit/Database/DatabaseDriverTestCase.php
@@ -139,13 +139,14 @@ abstract class DatabaseDriverTestCase extends TestCase
 
         $this->events->dispatch(new Events\Created($this->tenant));
 
-        Tenancy::getTenant();
-
         $this->assertTrue(
-            $this->db->connection(Tenancy::getTenantConnectionName())
+            $this->getTenantConnection()
                 ->getSchemaBuilder()
                 ->hasTable('mocks')
         );
+
+        $this->getTenantConnection()->insert('insert into mocks (id) values (?)', [1]);
+        $mocks = $this->getTenantConnection()->select('select * from mocks');
 
         $this->db->disconnect(Tenancy::getTenantConnectionName());
 
@@ -155,9 +156,14 @@ abstract class DatabaseDriverTestCase extends TestCase
         Tenancy::getTenant();
 
         $this->assertTrue(
-            $this->db->connection(Tenancy::getTenantConnectionName())
+            $this->getTenantConnection()
                 ->getSchemaBuilder()
                 ->hasTable('mocks')
+        );
+
+        $this->assertEquals(
+            $mocks,
+            $this->getTenantConnection()->select('select * from mocks')
         );
     }
 

--- a/tests/unit/Database/DatabaseDriverTestCase.php
+++ b/tests/unit/Database/DatabaseDriverTestCase.php
@@ -16,17 +16,17 @@ declare(strict_types=1);
 
 namespace Tenancy\Tests\Database;
 
-use PDO;
-use Tenancy\Tenant\Events;
-use Tenancy\Facades\Tenancy;
-use Tenancy\Testing\TestCase;
-use Tenancy\Testing\Mocks\Tenant;
-use Tenancy\Hooks\Migrations\Provider;
-use Tenancy\Tests\Database\Mocks\Mock;
-use Illuminate\Database\QueryException;
 use Illuminate\Database\DatabaseManager;
+use Illuminate\Database\QueryException;
+use PDO;
+use Tenancy\Facades\Tenancy;
+use Tenancy\Hooks\Migrations\Provider;
 use Tenancy\Identification\Contracts\ResolvesTenants;
 use Tenancy\Identification\Contracts\Tenant as TenantContract;
+use Tenancy\Tenant\Events;
+use Tenancy\Testing\Mocks\Tenant;
+use Tenancy\Testing\TestCase;
+use Tenancy\Tests\Database\Mocks\Mock;
 
 abstract class DatabaseDriverTestCase extends TestCase
 {

--- a/tests/unit/Database/DatabaseDriverTestCase.php
+++ b/tests/unit/Database/DatabaseDriverTestCase.php
@@ -16,16 +16,17 @@ declare(strict_types=1);
 
 namespace Tenancy\Tests\Database;
 
-use Illuminate\Database\DatabaseManager;
-use Illuminate\Database\QueryException;
 use PDO;
+use Tenancy\Tenant\Events;
 use Tenancy\Facades\Tenancy;
+use Tenancy\Testing\TestCase;
+use Tenancy\Testing\Mocks\Tenant;
 use Tenancy\Hooks\Migrations\Provider;
+use Tenancy\Tests\Database\Mocks\Mock;
+use Illuminate\Database\QueryException;
+use Illuminate\Database\DatabaseManager;
 use Tenancy\Identification\Contracts\ResolvesTenants;
 use Tenancy\Identification\Contracts\Tenant as TenantContract;
-use Tenancy\Tenant\Events;
-use Tenancy\Testing\Mocks\Tenant;
-use Tenancy\Testing\TestCase;
 
 abstract class DatabaseDriverTestCase extends TestCase
 {
@@ -36,6 +37,8 @@ abstract class DatabaseDriverTestCase extends TestCase
     protected $tenantModel = Tenant::class;
 
     protected $exception = QueryException::class;
+
+    protected $additionalMocks = [__DIR__.'/Mocks/factories'];
 
     protected function afterSetUp()
     {
@@ -145,8 +148,8 @@ abstract class DatabaseDriverTestCase extends TestCase
                 ->hasTable('mocks')
         );
 
-        $this->getTenantConnection()->insert('insert into mocks (id) values (?)', [1]);
-        $mocks = $this->getTenantConnection()->select('select * from mocks');
+        factory(Mock::class, 10)->create();
+        $mocks = Mock::all();
 
         $this->db->disconnect(Tenancy::getTenantConnectionName());
 
@@ -163,7 +166,7 @@ abstract class DatabaseDriverTestCase extends TestCase
 
         $this->assertEquals(
             $mocks,
-            $this->getTenantConnection()->select('select * from mocks')
+            Mock::all()
         );
     }
 

--- a/tests/unit/Database/Mocks/Mock.php
+++ b/tests/unit/Database/Mocks/Mock.php
@@ -1,11 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Laravel Tenancy & Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+
 namespace Tenancy\Tests\Database\Mocks;
 
 use Illuminate\Database\Eloquent\Model;
 use Tenancy\Eloquent\Connection\OnTenant;
 
-class Mock extends Model{
+class Mock extends Model
+{
     use OnTenant;
-
 }

--- a/tests/unit/Database/Mocks/Mock.php
+++ b/tests/unit/Database/Mocks/Mock.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tenancy\Tests\Database\Mocks;
+
+use Illuminate\Database\Eloquent\Model;
+use Tenancy\Eloquent\Connection\OnTenant;
+
+class Mock extends Model{
+    use OnTenant;
+
+}

--- a/tests/unit/Database/Mocks/factories/MockFactory.php
+++ b/tests/unit/Database/Mocks/factories/MockFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Laravel Tenancy & Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+
+use Faker\Generator as Faker;
+use Tenancy\Tests\Database\Mocks\Mock;
+
+/*
+|--------------------------------------------------------------------------
+| Model Factories
+|--------------------------------------------------------------------------
+|
+| This directory should contain each of the model factory definitions for
+| your application. Factories provide a convenient way to generate new
+| model instances for testing / seeding your application's database.
+|
+*/
+$factory->define(Mock::class, function (Faker $faker) {
+    return [
+
+    ];
+});

--- a/tests/unit/Database/Mysql/Mocks/Tenant.php
+++ b/tests/unit/Database/Mysql/Mocks/Tenant.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tenancy\Tests\Database\Mysql\Mocks;
+
+use Tenancy\Testing\Mocks;
+use Tenancy\Database\Drivers\Mysql\Concerns\ManagesSystemConnection;
+
+class Tenant extends Mocks\Tenant implements ManagesSystemConnection{
+    public function getManagingSystemConnection(): ?string
+    {
+        return "mysql";
+    }
+}

--- a/tests/unit/Database/Mysql/Mocks/Tenant.php
+++ b/tests/unit/Database/Mysql/Mocks/Tenant.php
@@ -1,13 +1,28 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Laravel Tenancy & Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+
 namespace Tenancy\Tests\Database\Mysql\Mocks;
 
-use Tenancy\Testing\Mocks;
 use Tenancy\Database\Drivers\Mysql\Concerns\ManagesSystemConnection;
+use Tenancy\Testing\Mocks;
 
-class Tenant extends Mocks\Tenant implements ManagesSystemConnection{
+class Tenant extends Mocks\Tenant implements ManagesSystemConnection
+{
     public function getManagingSystemConnection(): ?string
     {
-        return "mysql";
+        return 'mysql';
     }
 }

--- a/tests/unit/Database/Mysql/Mocks/factories/TenantFactory.php
+++ b/tests/unit/Database/Mysql/Mocks/factories/TenantFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Laravel Tenancy & Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+
+use Faker\Generator as Faker;
+use Tenancy\Tests\Database\Mysql\Mocks\Tenant;
+
+/*
+|--------------------------------------------------------------------------
+| Model Factories
+|--------------------------------------------------------------------------
+|
+| This directory should contain each of the model factory definitions for
+| your application. Factories provide a convenient way to generate new
+| model instances for testing / seeding your application's database.
+|
+*/
+$factory->define(Tenant::class, function (Faker $faker) {
+    return [
+        'name'           => $faker->slug,
+        'email'          => $faker->unique()->safeEmail,
+        'password'       => '$2y$10$TKh8H1.PfQx37YgCzwiKb.KjNyWgaHb9cbcoQgdIVFlYg7B77UdFm', // secret
+        'remember_token' => str_random(10),
+    ];
+});

--- a/tests/unit/Database/Mysql/MysqlDriverTest.php
+++ b/tests/unit/Database/Mysql/MysqlDriverTest.php
@@ -21,6 +21,9 @@ use Tenancy\Database\Drivers\Mysql\Provider;
 use Tenancy\Database\Events\Drivers\Configuring;
 use Tenancy\Tests\Database\DatabaseDriverTestCase;
 use Tenancy\Tests\Database\Mysql\Mocks\Tenant;
+use Tenancy\Database\Events\Drivers\Creating;
+use Tenancy\Database\Events\Drivers\Deleting;
+use Tenancy\Database\Events\Drivers\Updating;
 
 class MysqlDriverTest extends DatabaseDriverTestCase
 {
@@ -38,7 +41,13 @@ class MysqlDriverTest extends DatabaseDriverTestCase
         $this->events->listen(Configuring::class, function (Configuring $event) {
             $event->useConfig(
                 __DIR__.DIRECTORY_SEPARATOR.'database.php',
-                array_merge($event->configuration, ['allowedHost' => '%']));
+                $event->configuration);
+        });
+        $this->events->listen([Creating::class, Updating::class, Deleting::class], function (Configuring $event) {
+            $event->useConfig(
+                __DIR__.DIRECTORY_SEPARATOR.'database.php',
+                array_merge($event->configuration, ['host' => '%'])
+            );
         });
     }
 }

--- a/tests/unit/Database/Mysql/MysqlDriverTest.php
+++ b/tests/unit/Database/Mysql/MysqlDriverTest.php
@@ -19,11 +19,11 @@ namespace Tenancy\Tests\Database\Mysql;
 use PDOException;
 use Tenancy\Database\Drivers\Mysql\Provider;
 use Tenancy\Database\Events\Drivers\Configuring;
-use Tenancy\Tests\Database\DatabaseDriverTestCase;
-use Tenancy\Tests\Database\Mysql\Mocks\Tenant;
 use Tenancy\Database\Events\Drivers\Creating;
 use Tenancy\Database\Events\Drivers\Deleting;
 use Tenancy\Database\Events\Drivers\Updating;
+use Tenancy\Tests\Database\DatabaseDriverTestCase;
+use Tenancy\Tests\Database\Mysql\Mocks\Tenant;
 
 class MysqlDriverTest extends DatabaseDriverTestCase
 {

--- a/tests/unit/Database/Mysql/MysqlDriverTest.php
+++ b/tests/unit/Database/Mysql/MysqlDriverTest.php
@@ -18,9 +18,9 @@ namespace Tenancy\Tests\Database\Mysql;
 
 use PDOException;
 use Tenancy\Database\Drivers\Mysql\Provider;
-use Tenancy\Tests\Database\Mysql\Mocks\Tenant;
 use Tenancy\Database\Events\Drivers\Configuring;
 use Tenancy\Tests\Database\DatabaseDriverTestCase;
+use Tenancy\Tests\Database\Mysql\Mocks\Tenant;
 
 class MysqlDriverTest extends DatabaseDriverTestCase
 {

--- a/tests/unit/Database/Mysql/MysqlDriverTest.php
+++ b/tests/unit/Database/Mysql/MysqlDriverTest.php
@@ -43,7 +43,7 @@ class MysqlDriverTest extends DatabaseDriverTestCase
                 __DIR__.DIRECTORY_SEPARATOR.'database.php',
                 $event->configuration);
         });
-        $this->events->listen([Creating::class, Updating::class, Deleting::class], function (Configuring $event) {
+        $this->events->listen([Creating::class, Updating::class, Deleting::class], function ($event) {
             $event->useConfig(
                 __DIR__.DIRECTORY_SEPARATOR.'database.php',
                 array_merge($event->configuration, ['host' => '%'])

--- a/tests/unit/Database/Mysql/MysqlDriverTest.php
+++ b/tests/unit/Database/Mysql/MysqlDriverTest.php
@@ -14,22 +14,29 @@ declare(strict_types=1);
  * @see https://github.com/tenancy
  */
 
-namespace Tenancy\Tests\Database\Sqlite;
+namespace Tenancy\Tests\Database\Mysql;
 
+use PDOException;
 use Tenancy\Testing\DatabaseDriverTestCase;
-use Tenancy\Database\Drivers\Sqlite\Provider;
+use Tenancy\Database\Drivers\Mysql\Provider;
+use Tenancy\Tests\Database\Mysql\Mocks\Tenant;
 use Tenancy\Database\Events\Drivers\Configuring;
 
-class SqliteDriverTest extends DatabaseDriverTestCase{
+class MysqlDriverTest extends DatabaseDriverTestCase{
 
     protected $additionalProviders = [Provider::class];
 
+    protected $additionalMocks = [__DIR__.'/Mocks/factories/'];
+
+    protected $tenantModel = Tenant::class;
+
+    protected $exception = PDOException::class;
+
     protected function registerDatabaseListener()
     {
+        config(['database.connections.mysql' => include __DIR__.'/database.php']);
         $this->events->listen(Configuring::class, function (Configuring $event){
-            $event->useConfig(__DIR__. DIRECTORY_SEPARATOR . 'database.php', [
-                'database' => database_path($event->tenant->getTenantKey() . '.sqlite')
-            ]);
+            $event->useConfig(__DIR__. DIRECTORY_SEPARATOR . 'database.php', $event->configuration);
         });
     }
 }

--- a/tests/unit/Database/Mysql/MysqlDriverTest.php
+++ b/tests/unit/Database/Mysql/MysqlDriverTest.php
@@ -18,9 +18,9 @@ namespace Tenancy\Tests\Database\Mysql;
 
 use PDOException;
 use Tenancy\Database\Drivers\Mysql\Provider;
-use Tenancy\Database\Events\Drivers\Configuring;
-use Tenancy\Testing\DatabaseDriverTestCase;
 use Tenancy\Tests\Database\Mysql\Mocks\Tenant;
+use Tenancy\Database\Events\Drivers\Configuring;
+use Tenancy\Tests\Database\DatabaseDriverTestCase;
 
 class MysqlDriverTest extends DatabaseDriverTestCase
 {

--- a/tests/unit/Database/Mysql/MysqlDriverTest.php
+++ b/tests/unit/Database/Mysql/MysqlDriverTest.php
@@ -44,10 +44,7 @@ class MysqlDriverTest extends DatabaseDriverTestCase
                 $event->configuration);
         });
         $this->events->listen([Creating::class, Updating::class, Deleting::class], function ($event) {
-            $event->useConfig(
-                __DIR__.DIRECTORY_SEPARATOR.'database.php',
-                array_merge($event->configuration, ['host' => '%'])
-            );
+            $event->configuration['host'] = '%';
         });
     }
 }

--- a/tests/unit/Database/Mysql/MysqlDriverTest.php
+++ b/tests/unit/Database/Mysql/MysqlDriverTest.php
@@ -26,7 +26,7 @@ class MysqlDriverTest extends DatabaseDriverTestCase
 {
     protected $additionalProviders = [Provider::class];
 
-    protected $additionalMocks = [__DIR__.'/Mocks/factories/'];
+    protected $additionalMocks = [__DIR__.'/Mocks/factories/', __DIR__.'/../Mocks/factories'];
 
     protected $tenantModel = Tenant::class;
 

--- a/tests/unit/Database/Mysql/MysqlDriverTest.php
+++ b/tests/unit/Database/Mysql/MysqlDriverTest.php
@@ -17,13 +17,13 @@ declare(strict_types=1);
 namespace Tenancy\Tests\Database\Mysql;
 
 use PDOException;
-use Tenancy\Testing\DatabaseDriverTestCase;
 use Tenancy\Database\Drivers\Mysql\Provider;
-use Tenancy\Tests\Database\Mysql\Mocks\Tenant;
 use Tenancy\Database\Events\Drivers\Configuring;
+use Tenancy\Testing\DatabaseDriverTestCase;
+use Tenancy\Tests\Database\Mysql\Mocks\Tenant;
 
-class MysqlDriverTest extends DatabaseDriverTestCase{
-
+class MysqlDriverTest extends DatabaseDriverTestCase
+{
     protected $additionalProviders = [Provider::class];
 
     protected $additionalMocks = [__DIR__.'/Mocks/factories/'];
@@ -35,8 +35,8 @@ class MysqlDriverTest extends DatabaseDriverTestCase{
     protected function registerDatabaseListener()
     {
         config(['database.connections.mysql' => include __DIR__.'/database.php']);
-        $this->events->listen(Configuring::class, function (Configuring $event){
-            $event->useConfig(__DIR__. DIRECTORY_SEPARATOR . 'database.php', $event->configuration);
+        $this->events->listen(Configuring::class, function (Configuring $event) {
+            $event->useConfig(__DIR__.DIRECTORY_SEPARATOR.'database.php', $event->configuration);
         });
     }
 }

--- a/tests/unit/Database/Mysql/MysqlDriverTest.php
+++ b/tests/unit/Database/Mysql/MysqlDriverTest.php
@@ -36,7 +36,9 @@ class MysqlDriverTest extends DatabaseDriverTestCase
     {
         config(['database.connections.mysql' => include __DIR__.'/database.php']);
         $this->events->listen(Configuring::class, function (Configuring $event) {
-            $event->useConfig(__DIR__.DIRECTORY_SEPARATOR.'database.php', $event->configuration);
+            $event->useConfig(
+                __DIR__.DIRECTORY_SEPARATOR.'database.php',
+                array_merge($event->configuration, ['allowedHost' => '%']));
         });
     }
 }

--- a/tests/unit/Database/Mysql/database.php
+++ b/tests/unit/Database/Mysql/database.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 return [
     'driver'         => 'mysql',
-    'host'           => env('DB_HOST', '127.0.0.1'),
+    'host'           => env('TENANCY_HOST', '127.0.0.1'),
     'port'           => env('DB_PORT', '3306'),
-    'database'       => env('DB_DATABASE', 'forge'),
-    'username'       => env('DB_USERNAME', 'forge'),
-    'password'       => env('DB_PASSWORD', ''),
+    'database'       => env('TENANCY_DB', 'testing'),
+    'username'       => env('TENANCY_USERNAME', 'testing'),
+    'password'       => env('TENANCY_PASSWORD', ''),
     'unix_socket'    => env('DB_SOCKET', ''),
     'charset'        => 'utf8mb4',
     'collation'      => 'utf8mb4_unicode_ci',

--- a/tests/unit/Database/Sqlite/ConfiguresSqliteTest.php
+++ b/tests/unit/Database/Sqlite/ConfiguresSqliteTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Laravel Tenancy & Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+
+namespace Tenancy\Tests\Database\Sqlite;
+
+use Tenancy\Database\Drivers\Sqlite\Provider;
+use Tenancy\Database\Events\Drivers\Configuring;
+use Tenancy\Facades\Tenancy;
+use Tenancy\Testing\TestCase;
+
+class ConfiguresSqliteTest extends TestCase
+{
+    protected $additionalProviders = [Provider::class];
+
+    /**
+     * @test
+     */
+    public function reads_config_file()
+    {
+        $this->events->listen(Configuring::class, function (Configuring $event) {
+            $event->useConfig(__DIR__.'/database.php');
+        });
+
+        $this->resolveTenant($tenant = $this->mockTenant());
+        Tenancy::getTenant();
+
+        $config = include __DIR__.'/database.php';
+
+        $config['tenant-key'] = $tenant->getTenantKey();
+        $config['tenant-identifier'] = $tenant->getTenantIdentifier();
+
+        $this->assertEquals(
+            $config,
+            config('database.connections.tenant')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function mimicks_connection()
+    {
+        $this->resolveTenant($tenant = $this->mockTenant());
+
+        $config = config('database.connections.sqlite');
+        $config['database'] = $tenant->getTenantKey() . '.sqlite';
+
+        $this->events->listen(Configuring::class, function (Configuring $event) {
+            $event->useConnection('sqlite', [
+                'database' => $event->tenant->getTenantKey() . '.sqlite',
+            ]);
+        });
+
+        Tenancy::getTenant();
+
+        $config['tenant-key'] = $tenant->getTenantKey();
+        $config['tenant-identifier'] = $tenant->getTenantIdentifier();
+
+        $this->assertEquals(
+            $config,
+            config('database.connections.tenant')
+        );
+    }
+}

--- a/tests/unit/Database/Sqlite/ConfiguresSqliteTest.php
+++ b/tests/unit/Database/Sqlite/ConfiguresSqliteTest.php
@@ -56,11 +56,11 @@ class ConfiguresSqliteTest extends TestCase
         $this->resolveTenant($tenant = $this->mockTenant());
 
         $config = config('database.connections.sqlite');
-        $config['database'] = $tenant->getTenantKey() . '.sqlite';
+        $config['database'] = $tenant->getTenantKey().'.sqlite';
 
         $this->events->listen(Configuring::class, function (Configuring $event) {
             $event->useConnection('sqlite', [
-                'database' => $event->tenant->getTenantKey() . '.sqlite',
+                'database' => $event->tenant->getTenantKey().'.sqlite',
             ]);
         });
 

--- a/tests/unit/Database/Sqlite/SqliteDriverTest.php
+++ b/tests/unit/Database/Sqlite/SqliteDriverTest.php
@@ -16,19 +16,19 @@ declare(strict_types=1);
 
 namespace Tenancy\Tests\Database\Sqlite;
 
-use Tenancy\Testing\DatabaseDriverTestCase;
 use Tenancy\Database\Drivers\Sqlite\Provider;
 use Tenancy\Database\Events\Drivers\Configuring;
+use Tenancy\Testing\DatabaseDriverTestCase;
 
-class SqliteDriverTest extends DatabaseDriverTestCase{
-
+class SqliteDriverTest extends DatabaseDriverTestCase
+{
     protected $additionalProviders = [Provider::class];
 
     protected function registerDatabaseListener()
     {
-        $this->events->listen(Configuring::class, function (Configuring $event){
-            $event->useConfig(__DIR__. DIRECTORY_SEPARATOR . 'database.php', [
-                'database' => database_path($event->tenant->getTenantKey() . '.sqlite')
+        $this->events->listen(Configuring::class, function (Configuring $event) {
+            $event->useConfig(__DIR__.DIRECTORY_SEPARATOR.'database.php', [
+                'database' => database_path($event->tenant->getTenantKey().'.sqlite'),
             ]);
         });
     }

--- a/tests/unit/Database/Sqlite/SqliteDriverTest.php
+++ b/tests/unit/Database/Sqlite/SqliteDriverTest.php
@@ -18,7 +18,7 @@ namespace Tenancy\Tests\Database\Sqlite;
 
 use Tenancy\Database\Drivers\Sqlite\Provider;
 use Tenancy\Database\Events\Drivers\Configuring;
-use Tenancy\Testing\DatabaseDriverTestCase;
+use Tenancy\Tests\Database\DatabaseDriverTestCase;
 
 class SqliteDriverTest extends DatabaseDriverTestCase
 {

--- a/tests/unit/Database/Sqlite/database.php
+++ b/tests/unit/Database/Sqlite/database.php
@@ -15,16 +15,9 @@ declare(strict_types=1);
  */
 
 return [
-    /*
-     * If you want to re-use an existing connection,
-     * specify its name here. Leave null to
-     * instantiate a fully new connection.
-     */
-    'use-connection' => null,
-
-    'preset' => [
-        'driver'   => 'sqlite',
-        'database' => env('DB_DATABASE', database_path('database.sqlite')),
-        'prefix'   => '',
-    ],
+    'driver' => 'sqlite',
+    'url' => env('DATABASE_URL'),
+    'database' => env('DB_DATABASE', database_path('database.sqlite')),
+    'prefix' => '',
+    'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
 ];

--- a/tests/unit/Database/Sqlite/database.php
+++ b/tests/unit/Database/Sqlite/database.php
@@ -15,9 +15,9 @@ declare(strict_types=1);
  */
 
 return [
-    'driver' => 'sqlite',
-    'url' => env('DATABASE_URL'),
-    'database' => env('DB_DATABASE', database_path('database.sqlite')),
-    'prefix' => '',
+    'driver'                  => 'sqlite',
+    'url'                     => env('DATABASE_URL'),
+    'database'                => env('DB_DATABASE', database_path('database.sqlite')),
+    'prefix'                  => '',
     'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
 ];

--- a/tests/unit/Database/migrations/2019_05_29_234600_creates_mock_table.php
+++ b/tests/unit/Database/migrations/2019_05_29_234600_creates_mock_table.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Laravel Tenancy & Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatesMockTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('mocks', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::drop('mocks');
+    }
+}

--- a/tests/unit/Database/migrations/2019_05_29_234600_creates_mocks_table.php
+++ b/tests/unit/Database/migrations/2019_05_29_234600_creates_mocks_table.php
@@ -24,7 +24,6 @@ class CreatesMocksTable extends Migration
     {
         Schema::create('mocks', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('name');
             $table->timestamps();
         });
     }

--- a/tests/unit/Database/migrations/2019_05_29_234600_creates_mocks_table.php
+++ b/tests/unit/Database/migrations/2019_05_29_234600_creates_mocks_table.php
@@ -18,7 +18,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreatesMockTable extends Migration
+class CreatesMocksTable extends Migration
 {
     public function up()
     {

--- a/tests/unit/Hooks/Migrations/ConfiguresMigrationsTest.php
+++ b/tests/unit/Hooks/Migrations/ConfiguresMigrationsTest.php
@@ -24,6 +24,7 @@ use Tenancy\Hooks\Migrations\Events\ConfigureMigrations;
 use Tenancy\Hooks\Migrations\Provider;
 use Tenancy\Tenant\Events\Created;
 use Tenancy\Testing\TestCase;
+use Tenancy\Database\Events\Drivers\Configuring;
 
 class ConfiguresMigrationsTest extends TestCase
 {
@@ -41,6 +42,12 @@ class ConfiguresMigrationsTest extends TestCase
 
         $this->events->listen(ConfigureMigrations::class, function (ConfigureMigrations $event) {
             $event->path(__DIR__.'/database/');
+        });
+
+        $this->events->listen(Configuring::class, function (Configuring $event){
+            $event->useConfig(__DIR__. DIRECTORY_SEPARATOR . 'database.php', [
+                'database' => database_path($event->tenant->getTenantKey() . '.sqlite')
+            ]);
         });
     }
 

--- a/tests/unit/Hooks/Migrations/ConfiguresMigrationsTest.php
+++ b/tests/unit/Hooks/Migrations/ConfiguresMigrationsTest.php
@@ -19,12 +19,12 @@ namespace Tenancy\Tests\Hooks\Migrations;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 use Tenancy\Database\Drivers\Sqlite\Provider as DatabaseProvider;
+use Tenancy\Database\Events\Drivers\Configuring;
 use Tenancy\Facades\Tenancy;
 use Tenancy\Hooks\Migrations\Events\ConfigureMigrations;
 use Tenancy\Hooks\Migrations\Provider;
 use Tenancy\Tenant\Events\Created;
 use Tenancy\Testing\TestCase;
-use Tenancy\Database\Events\Drivers\Configuring;
 
 class ConfiguresMigrationsTest extends TestCase
 {
@@ -44,9 +44,9 @@ class ConfiguresMigrationsTest extends TestCase
             $event->path(__DIR__.'/database/');
         });
 
-        $this->events->listen(Configuring::class, function (Configuring $event){
-            $event->useConfig(__DIR__. DIRECTORY_SEPARATOR . 'database.php', [
-                'database' => database_path($event->tenant->getTenantKey() . '.sqlite')
+        $this->events->listen(Configuring::class, function (Configuring $event) {
+            $event->useConfig(__DIR__.DIRECTORY_SEPARATOR.'database.php', [
+                'database' => database_path($event->tenant->getTenantKey().'.sqlite'),
             ]);
         });
     }

--- a/tests/unit/Hooks/Migrations/MigratesHookTest.php
+++ b/tests/unit/Hooks/Migrations/MigratesHookTest.php
@@ -24,6 +24,7 @@ use Tenancy\Tenant\Events\Created;
 use Tenancy\Tenant\Events\Deleted;
 use Tenancy\Testing\Mocks\Tenant;
 use Tenancy\Testing\TestCase;
+use Tenancy\Database\Events\Drivers\Configuring;
 
 class MigratesHookTest extends TestCase
 {
@@ -45,6 +46,12 @@ class MigratesHookTest extends TestCase
         $this->migrateTenant(__DIR__.'/database/');
 
         $this->defaultConnection = DB::getDefaultConnection();
+
+        $this->events->listen(Configuring::class, function (Configuring $event){
+            $event->useConfig(__DIR__. DIRECTORY_SEPARATOR . 'database.php', [
+                'database' => database_path($event->tenant->getTenantKey() . '.sqlite')
+            ]);
+        });
 
         $this->events->dispatch(new Created($this->tenant));
     }

--- a/tests/unit/Hooks/Migrations/MigratesHookTest.php
+++ b/tests/unit/Hooks/Migrations/MigratesHookTest.php
@@ -18,13 +18,13 @@ namespace Tenancy\Tests\Hooks\Migrations;
 
 use Illuminate\Support\Facades\DB;
 use Tenancy\Database\Drivers\Sqlite\Provider as DatabaseProvider;
+use Tenancy\Database\Events\Drivers\Configuring;
 use Tenancy\Facades\Tenancy;
 use Tenancy\Hooks\Migrations\Provider;
 use Tenancy\Tenant\Events\Created;
 use Tenancy\Tenant\Events\Deleted;
 use Tenancy\Testing\Mocks\Tenant;
 use Tenancy\Testing\TestCase;
-use Tenancy\Database\Events\Drivers\Configuring;
 
 class MigratesHookTest extends TestCase
 {
@@ -47,9 +47,9 @@ class MigratesHookTest extends TestCase
 
         $this->defaultConnection = DB::getDefaultConnection();
 
-        $this->events->listen(Configuring::class, function (Configuring $event){
-            $event->useConfig(__DIR__. DIRECTORY_SEPARATOR . 'database.php', [
-                'database' => database_path($event->tenant->getTenantKey() . '.sqlite')
+        $this->events->listen(Configuring::class, function (Configuring $event) {
+            $event->useConfig(__DIR__.DIRECTORY_SEPARATOR.'database.php', [
+                'database' => database_path($event->tenant->getTenantKey().'.sqlite'),
             ]);
         });
 

--- a/tests/unit/Hooks/Migrations/SeedsHookTest.php
+++ b/tests/unit/Hooks/Migrations/SeedsHookTest.php
@@ -18,12 +18,12 @@ namespace Tenancy\Tests\Hooks\Migrations;
 
 use Illuminate\Support\Facades\DB;
 use Tenancy\Database\Drivers\Sqlite\Provider as DatabaseProvider;
+use Tenancy\Database\Events\Drivers\Configuring;
 use Tenancy\Facades\Tenancy;
 use Tenancy\Hooks\Migrations\Provider;
 use Tenancy\Tenant\Events\Created;
 use Tenancy\Testing\Mocks\Tenant;
 use Tenancy\Testing\TestCase;
-use Tenancy\Database\Events\Drivers\Configuring;
 
 class SeedsHookTest extends TestCase
 {
@@ -47,9 +47,9 @@ class SeedsHookTest extends TestCase
 
         $this->defaultConnection = DB::getDefaultConnection();
 
-        $this->events->listen(Configuring::class, function (Configuring $event){
-            $event->useConfig(__DIR__. DIRECTORY_SEPARATOR . 'database.php', [
-                'database' => database_path($event->tenant->getTenantKey() . '.sqlite')
+        $this->events->listen(Configuring::class, function (Configuring $event) {
+            $event->useConfig(__DIR__.DIRECTORY_SEPARATOR.'database.php', [
+                'database' => database_path($event->tenant->getTenantKey().'.sqlite'),
             ]);
         });
 

--- a/tests/unit/Hooks/Migrations/SeedsHookTest.php
+++ b/tests/unit/Hooks/Migrations/SeedsHookTest.php
@@ -23,6 +23,7 @@ use Tenancy\Hooks\Migrations\Provider;
 use Tenancy\Tenant\Events\Created;
 use Tenancy\Testing\Mocks\Tenant;
 use Tenancy\Testing\TestCase;
+use Tenancy\Database\Events\Drivers\Configuring;
 
 class SeedsHookTest extends TestCase
 {
@@ -45,6 +46,12 @@ class SeedsHookTest extends TestCase
         $this->seedTenant(__DIR__.'/seeds/MockSeeder.php');
 
         $this->defaultConnection = DB::getDefaultConnection();
+
+        $this->events->listen(Configuring::class, function (Configuring $event){
+            $event->useConfig(__DIR__. DIRECTORY_SEPARATOR . 'database.php', [
+                'database' => database_path($event->tenant->getTenantKey() . '.sqlite')
+            ]);
+        });
 
         $this->events->dispatch(new Created($this->tenant));
     }

--- a/tests/unit/Hooks/Migrations/database.php
+++ b/tests/unit/Hooks/Migrations/database.php
@@ -14,12 +14,10 @@ declare(strict_types=1);
  * @see https://github.com/tenancy
  */
 
-namespace Tenancy\Database\Drivers\Sqlite;
-
-use Tenancy\Database\Drivers\Sqlite\Listeners\ConfiguresTenantConnection;
-use Tenancy\Support\DatabaseProvider;
-
-class Provider extends DatabaseProvider
-{
-    protected $listener = ConfiguresTenantConnection::class;
-}
+return [
+    'driver' => 'sqlite',
+    'url' => env('DATABASE_URL'),
+    'database' => env('DB_DATABASE', database_path('database.sqlite')),
+    'prefix' => '',
+    'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
+];

--- a/tests/unit/Hooks/Migrations/database.php
+++ b/tests/unit/Hooks/Migrations/database.php
@@ -15,9 +15,9 @@ declare(strict_types=1);
  */
 
 return [
-    'driver' => 'sqlite',
-    'url' => env('DATABASE_URL'),
-    'database' => env('DB_DATABASE', database_path('database.sqlite')),
-    'prefix' => '',
+    'driver'                  => 'sqlite',
+    'url'                     => env('DATABASE_URL'),
+    'database'                => env('DB_DATABASE', database_path('database.sqlite')),
+    'prefix'                  => '',
     'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
 ];


### PR DESCRIPTION
Total changelog
- Added variables to PHPUnit in order to make testing of DB's easier.
- Remove the need for a config of the SQLite Driver. Removed all references to the config in the code.
- Changed the Database Configuring useConfig function to allow overriding by providing an array just like the useConnection function.
- Made sure the Migrations Hooks reflect the SQLite Driver change and provide their own SQLite config.
- Made Database Driver Testing into its own Abstract function
- Database Driver Test that tests: Creating, Updating, Preventing Update when the Tenant key has not changed, Updating moves tables as well, Deleting
- Update code to update Tenant's table's with their previous data by moving the tables.
- Created a new SQLite Driver Test
- Created a new MySQL Driver Test