### PR TITLE
Fix some consistency and separating small bits

### DIFF
--- a/src/Tenancy/Providers/Provides/ProvidesAffects.php
+++ b/src/Tenancy/Providers/Provides/ProvidesAffects.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Laravel Tenancy & Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+
+namespace Tenancy\Providers\Provides;
+
+use Tenancy\Affects\Contracts\ResolvesAffects;
+
+trait ProvidesAffects
+{
+    protected function bootProvidesAffects()
+    {
+        if (count($this->affects)) {
+            $this->app->resolving(ResolvesAffects::class, function (ResolvesAffects $resolver) {
+                foreach ($this->affects as $affect) {
+                    $resolver->addAffect($affect);
+                }
+            });
+        }
+    }
+}

--- a/src/Tenancy/Providers/Provides/ProvidesConfig.php
+++ b/src/Tenancy/Providers/Provides/ProvidesConfig.php
@@ -18,10 +18,6 @@ namespace Tenancy\Providers\Provides;
 
 trait ProvidesConfig
 {
-    protected $configs = [
-        __DIR__.'/../../resources/config/tenancy.php' => 'tenancy',
-    ];
-
     protected function registerProvidesConfig()
     {
         foreach ($this->configs as $path => $key) {

--- a/src/Tenancy/Providers/Provides/ProvidesHooks.php
+++ b/src/Tenancy/Providers/Provides/ProvidesHooks.php
@@ -16,15 +16,10 @@ declare(strict_types=1);
 
 namespace Tenancy\Providers\Provides;
 
-use Tenancy\Database\Hooks\DatabaseMutation;
 use Tenancy\Lifecycle\Contracts\ResolvesHooks;
 
 trait ProvidesHooks
 {
-    protected $hooks = [
-        DatabaseMutation::class,
-    ];
-
     protected function bootProvidesHooks()
     {
         if (count($this->hooks)) {

--- a/src/Tenancy/Providers/Provides/ProvidesListeners.php
+++ b/src/Tenancy/Providers/Provides/ProvidesListeners.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Tenancy\Providers\Provides;
 
 use Illuminate\Support\Facades\Event;
+
 trait ProvidesListeners
 {
     public function bootProvidesListeners()

--- a/src/Tenancy/Providers/Provides/ProvidesListeners.php
+++ b/src/Tenancy/Providers/Provides/ProvidesListeners.php
@@ -17,47 +17,8 @@ declare(strict_types=1);
 namespace Tenancy\Providers\Provides;
 
 use Illuminate\Support\Facades\Event;
-use Tenancy\Affects\Contracts\ResolvesAffects;
-use Tenancy\Database\Contracts\ResolvesConnections;
-use Tenancy\Database\Events as Database;
-use Tenancy\Database\Listeners as Listen;
-use Tenancy\Identification\Events\Switched;
-use Tenancy\Lifecycle\Contracts\ResolvesHooks;
-use Tenancy\Tenant\Events as Tenant;
-
 trait ProvidesListeners
 {
-    /**
-     * The event handler mappings for the application.
-     *
-     * @var array
-     */
-    protected $listen = [
-        Tenant\Created::class => [
-            ResolvesHooks::class,
-        ],
-        Tenant\Updated::class => [
-            ResolvesHooks::class,
-        ],
-        Tenant\Deleted::class => [
-            ResolvesHooks::class,
-        ],
-        Database\Resolved::class => [
-            Listen\SetConnection::class,
-        ],
-        Switched::class => [
-            ResolvesAffects::class,
-        ],
-    ];
-
-    /**
-     * The subscriber classes to register.
-     *
-     * @var array
-     */
-    protected $subscribe = [
-    ];
-
     public function bootProvidesListeners()
     {
         foreach ($this->listen as $event => $listeners) {
@@ -65,8 +26,6 @@ trait ProvidesListeners
                 Event::listen($event, $listener);
             }
         }
-
-        $this->subscribe[] = resolve(ResolvesConnections::class);
 
         foreach ($this->subscribe as $subscriber) {
             Event::subscribe($subscriber);

--- a/src/Tenancy/Providers/TenancyProvider.php
+++ b/src/Tenancy/Providers/TenancyProvider.php
@@ -22,16 +22,16 @@ use Tenancy\Affects\Contracts\ResolvesAffects;
 use Tenancy\Database\Contracts\ProvidesPassword;
 use Tenancy\Database\Contracts\ResolvesConnections;
 use Tenancy\Database\DatabaseResolver;
+use Tenancy\Database\Events as Database;
+use Tenancy\Database\Hooks\DatabaseMutation;
+use Tenancy\Database\Listeners as Listen;
 use Tenancy\Database\PasswordGenerator;
 use Tenancy\Environment;
 use Tenancy\Identification\Contracts\ResolvesTenants;
+use Tenancy\Identification\Events\Switched;
 use Tenancy\Identification\TenantResolver;
 use Tenancy\Lifecycle\Contracts\ResolvesHooks;
 use Tenancy\Lifecycle\HookResolver;
-use Tenancy\Database\Hooks\DatabaseMutation;
-use Tenancy\Database\Events as Database;
-use Tenancy\Database\Listeners as Listen;
-use Tenancy\Identification\Events\Switched;
 use Tenancy\Tenant\Events as Tenant;
 
 class TenancyProvider extends ServiceProvider

--- a/src/Tenancy/Support/AffectsProvider.php
+++ b/src/Tenancy/Support/AffectsProvider.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Tenancy\Support;
 
-use Tenancy\Support\Provider;
 use Tenancy\Providers\Provides\ProvidesAffects;
 
 abstract class AffectsProvider extends Provider

--- a/src/Tenancy/Support/AffectsProvider.php
+++ b/src/Tenancy/Support/AffectsProvider.php
@@ -16,31 +16,10 @@ declare(strict_types=1);
 
 namespace Tenancy\Support;
 
-use Illuminate\Support\ServiceProvider;
+use Tenancy\Support\Provider;
 use Tenancy\Providers\Provides\ProvidesAffects;
 
-abstract class AffectsProvider extends ServiceProvider
+abstract class AffectsProvider extends Provider
 {
     use ProvidesAffects;
-
-    public function register()
-    {
-        $this->runTrait('register');
-    }
-
-    public function boot()
-    {
-        $this->runTrait('boot');
-    }
-
-    protected function runTrait(string $runtime)
-    {
-        $class = static::class;
-
-        foreach (class_uses_recursive($class) as $trait) {
-            if (method_exists($class, $method = $runtime.class_basename($trait))) {
-                call_user_func([$this, $method]);
-            }
-        }
-    }
 }

--- a/src/Tenancy/Support/DatabaseProvider.php
+++ b/src/Tenancy/Support/DatabaseProvider.php
@@ -17,10 +17,10 @@ declare(strict_types=1);
 namespace Tenancy\Support;
 
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\ServiceProvider;
 use Tenancy\Database\Events\Resolving;
+use Tenancy\Support\Provider;
 
-abstract class DatabaseProvider extends ServiceProvider
+abstract class DatabaseProvider extends Provider
 {
     use Concerns\PublishesConfigs;
 
@@ -33,6 +33,7 @@ abstract class DatabaseProvider extends ServiceProvider
 
     public function register()
     {
+        parent::register();
         if ($this->listener) {
             Event::listen(Resolving::class, $this->listener);
         }

--- a/src/Tenancy/Support/DatabaseProvider.php
+++ b/src/Tenancy/Support/DatabaseProvider.php
@@ -18,7 +18,6 @@ namespace Tenancy\Support;
 
 use Illuminate\Support\Facades\Event;
 use Tenancy\Database\Events\Resolving;
-use Tenancy\Support\Provider;
 
 abstract class DatabaseProvider extends Provider
 {

--- a/src/Tenancy/Support/DriverProvider.php
+++ b/src/Tenancy/Support/DriverProvider.php
@@ -16,10 +16,10 @@ declare(strict_types=1);
 
 namespace Tenancy\Support;
 
-use Illuminate\Support\ServiceProvider;
+use Tenancy\Support\Provider;
 use Tenancy\Identification\Contracts\ResolvesTenants;
 
-abstract class DriverProvider extends ServiceProvider
+abstract class DriverProvider extends Provider
 {
     use Concerns\PublishesConfigs;
     /**
@@ -31,6 +31,7 @@ abstract class DriverProvider extends ServiceProvider
 
     public function register()
     {
+        parent::register();
         $this->app->resolving(ResolvesTenants::class, function (ResolvesTenants $resolver) {
             foreach ($this->drivers as $contract => $method) {
                 $resolver->registerDriver($contract, $method);

--- a/src/Tenancy/Support/DriverProvider.php
+++ b/src/Tenancy/Support/DriverProvider.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Tenancy\Support;
 
-use Tenancy\Support\Provider;
 use Tenancy\Identification\Contracts\ResolvesTenants;
 
 abstract class DriverProvider extends Provider

--- a/src/Tenancy/Support/HooksProvider.php
+++ b/src/Tenancy/Support/HooksProvider.php
@@ -16,25 +16,10 @@ declare(strict_types=1);
 
 namespace Tenancy\Support;
 
-use Illuminate\Support\ServiceProvider;
-use Tenancy\Lifecycle\Contracts\ResolvesHooks;
+use Tenancy\Providers\Provides\ProvidesHooks;
+use Tenancy\Support\Provider;
 
-abstract class HooksProvider extends ServiceProvider
+abstract class HooksProvider extends Provider
 {
-    /**
-     * Lifecycle event hooks. Hooks that run specific logic
-     * during Tenant creation, updates or deletion.
-     *
-     * @var array
-     */
-    protected $hooks = [];
-
-    public function register()
-    {
-        $this->app->resolving(ResolvesHooks::class, function (ResolvesHooks $resolver) {
-            foreach ($this->hooks as $hook) {
-                $resolver->addHook($hook);
-            }
-        });
-    }
+    use ProvidesHooks;
 }

--- a/src/Tenancy/Support/HooksProvider.php
+++ b/src/Tenancy/Support/HooksProvider.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Tenancy\Support;
 
 use Tenancy\Providers\Provides\ProvidesHooks;
-use Tenancy\Support\Provider;
 
 abstract class HooksProvider extends Provider
 {

--- a/src/Tenancy/Support/Provider.php
+++ b/src/Tenancy/Support/Provider.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Laravel Tenancy & Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+
+namespace Tenancy\Support;
+
+use Illuminate\Support\ServiceProvider;
+
+abstract class Provider extends ServiceProvider
+{
+    public function register()
+    {
+        $this->runTrait('register');
+    }
+
+    public function boot()
+    {
+        $this->runTrait('boot');
+    }
+
+    protected function runTrait(string $runtime)
+    {
+        $class = static::class;
+
+        foreach (class_uses_recursive($class) as $trait) {
+            if (method_exists($class, $method = $runtime.class_basename($trait))) {
+                call_user_func([$this, $method]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Every variable in the Provides Traits are gone now and are actually set in the provider.
- Created ProvidesAffects so the use is consistent across all providers (same as hooks)

More reason on why I want this has to do with the DB separating :)
This will temporarily make the TenancyProvider a bit bigger, but we will make it a lot smaller when the DB Separating is done. Want to do it in 2 different PR's though.