### PR TITLE
Generalize testing of affects

### DIFF
--- a/src/Affects/Mails/ConfiguresMail.php
+++ b/src/Affects/Mails/ConfiguresMail.php
@@ -32,7 +32,7 @@ class ConfiguresMail extends Affect
         if ($this->event->tenant) {
             $this->events()->dispatch(new Events\ConfigureMail($this->event, $mailer));
         } else {
-            $mailer->setSwiftMailer(resolve('swift.mailer'));
+            app()->forgetInstance('mailer');
         }
     }
 }

--- a/src/Affects/Mails/ConfiguresMail.php
+++ b/src/Affects/Mails/ConfiguresMail.php
@@ -31,6 +31,8 @@ class ConfiguresMail extends Affect
 
         if ($this->event->tenant) {
             $this->events()->dispatch(new Events\ConfigureMail($this->event, $mailer));
+        } else {
+            $mailer->setSwiftMailer(resolve('swift.mailer'));
         }
     }
 }

--- a/src/Affects/Mails/ConfiguresMail.php
+++ b/src/Affects/Mails/ConfiguresMail.php
@@ -31,8 +31,6 @@ class ConfiguresMail extends Affect
 
         if ($this->event->tenant) {
             $this->events()->dispatch(new Events\ConfigureMail($this->event, $mailer));
-        } else {
-            app()->forgetInstance('mailer');
         }
     }
 }

--- a/src/Affects/Routes/ConfiguresRoutes.php
+++ b/src/Affects/Routes/ConfiguresRoutes.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Tenancy\Affects\Routes;
 
+use Illuminate\Routing\RouteCollection;
 use Illuminate\Routing\Router;
 use Tenancy\Affects\Affect;
 use Tenancy\Concerns\DispatchesEvents;
@@ -31,6 +32,8 @@ class ConfiguresRoutes extends Affect
 
         if ($this->event->tenant) {
             $this->events()->dispatch(new Events\ConfigureRoutes($this->event, $router));
+        } else {
+            $router->setRoutes(new RouteCollection());
         }
 
         $router->getRoutes()->refreshNameLookups();

--- a/src/Affects/URLs/ConfiguresURL.php
+++ b/src/Affects/URLs/ConfiguresURL.php
@@ -31,6 +31,8 @@ class ConfiguresURL extends Affect
 
         if ($this->event->tenant) {
             $this->events()->dispatch(new Events\ConfigureURL($this->event, $url));
+        } else {
+            $url->forceRootUrl(null);
         }
     }
 }

--- a/tests/unit/Affects/AffectsTestCase.php
+++ b/tests/unit/Affects/AffectsTestCase.php
@@ -32,6 +32,11 @@ abstract class AffectsTestCase extends TestCase
      */
     protected $forwardCallTest = true;
 
+    /**
+     * @var bool
+     */
+    protected $undoTest = true;
+
     protected function afterSetUp()
     {
         $this->tenant = $this->mockTenant();
@@ -80,6 +85,12 @@ abstract class AffectsTestCase extends TestCase
      */
     public function affects_can_be_undone()
     {
+        if (!$this->undoTest) {
+            $this->markTestSkipped();
+
+            return;
+        }
+
         $this->registerAffecting();
         $this->identifyTenant($this->tenant);
 

--- a/tests/unit/Affects/AffectsTestCase.php
+++ b/tests/unit/Affects/AffectsTestCase.php
@@ -87,7 +87,7 @@ abstract class AffectsTestCase extends TestCase
     public function can_forward_calls()
     {
         if (!$this->forwardCallTest) {
-            $this->assertTrue(true);
+            $this->markTestSkipped();
 
             return;
         }

--- a/tests/unit/Affects/AffectsTestCase.php
+++ b/tests/unit/Affects/AffectsTestCase.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Tenancy for Laravel & Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+
+namespace Tenancy\Tests\Affects;
+
+use Tenancy\Facades\Tenancy;
+use Tenancy\Testing\Mocks\Tenant;
+use Tenancy\Testing\TestCase;
+
+abstract class AffectsTestCase extends TestCase
+{
+    /**
+     * @var Tenant
+     */
+    protected $tenant;
+
+    /**
+     * @var bool
+     */
+    protected $forwardCallTest = true;
+
+    protected function afterSetUp()
+    {
+        $this->tenant = $this->mockTenant();
+    }
+
+    abstract protected function assertAffected(Tenant $tenant);
+    abstract protected function assertNotAffected();
+    abstract protected function registerAffecting();
+    abstract protected function registerForwardingCall();
+
+
+    /**
+     * @test
+     */
+    public function not_affected_by_default()
+    {
+        $this->registerAffecting();
+        $this->assertNotAffected();
+    }
+
+    /**
+     * @test
+     */
+    public function can_affect_the_application()
+    {
+        $this->registerAffecting();
+        $this->assertNotAffected();
+
+        Tenancy::setTenant($this->tenant);
+
+        $this->assertAffected($this->tenant);
+    }
+
+    /**
+     * @test
+     */
+    public function can_override_previous_affect()
+    {
+        $this->registerAffecting();
+        Tenancy::setTenant($this->tenant);
+
+        $this->assertAffected($this->tenant);
+
+        $newTenant = $this->mockTenant();
+        Tenancy::setTenant($newTenant);
+    }
+
+    /**
+     * @test
+     */
+    public function can_forward_calls()
+    {
+        if(!$this->forwardCallTest)
+        {
+            $this->assertTrue(true);
+            return;
+        }
+
+        $this->registerForwardingCall();
+        $this->assertNotAffected();
+
+        Tenancy::setTenant($this->tenant);
+
+        $this->assertAffected($this->tenant);
+    }
+}

--- a/tests/unit/Affects/AffectsTestCase.php
+++ b/tests/unit/Affects/AffectsTestCase.php
@@ -48,7 +48,10 @@ abstract class AffectsTestCase extends TestCase
 
     abstract protected function registerAffecting();
 
-    abstract protected function registerForwardingCall();
+    protected function registerForwardingCall()
+    {
+        //
+    }
 
     protected function beforeIdentification(Tenant $tenant = null)
     {

--- a/tests/unit/Affects/AffectsTestCase.php
+++ b/tests/unit/Affects/AffectsTestCase.php
@@ -38,10 +38,12 @@ abstract class AffectsTestCase extends TestCase
     }
 
     abstract protected function assertAffected(Tenant $tenant);
-    abstract protected function assertNotAffected();
-    abstract protected function registerAffecting();
-    abstract protected function registerForwardingCall();
 
+    abstract protected function assertNotAffected();
+
+    abstract protected function registerAffecting();
+
+    abstract protected function registerForwardingCall();
 
     /**
      * @test
@@ -84,9 +86,9 @@ abstract class AffectsTestCase extends TestCase
      */
     public function can_forward_calls()
     {
-        if(!$this->forwardCallTest)
-        {
+        if (!$this->forwardCallTest) {
             $this->assertTrue(true);
+
             return;
         }
 

--- a/tests/unit/Affects/Mails/ConfigureMailNewTest.php
+++ b/tests/unit/Affects/Mails/ConfigureMailNewTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Tenancy for Laravel & Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+
+namespace Tenancy\Tests\Affects\Mails;
+
+use Illuminate\Support\Facades\Mail;
+use Swift_Message;
+use Tenancy\Affects\Mails\Events\ConfigureMail;
+use Tenancy\Affects\Mails\Provider;
+use Tenancy\Identification\Contracts\Tenant;
+use Tenancy\Tests\Affects\AffectsTestCase;
+
+class ConfigureMailNewTest extends AffectsTestCase
+{
+    /**
+     * @var bool
+     */
+    protected $forwardCallTest = false;
+
+    protected $additionalProviders = [Provider::class];
+
+    public $email;
+
+    protected function afterSetUp()
+    {
+        $this->app->resolving('mailer', function ($Mailer) {
+            $Mailer->getSwiftMailer()->registerPlugin(new SwiftTestPlugin($this));
+        });
+
+        parent::afterSetUp();
+    }
+
+    protected function getAddressFromMessage(Swift_Message $message = null)
+    {
+        if(empty($message)){
+            return '';
+        }
+        return array_keys($message->getFrom())[0];
+    }
+
+    protected function registerAffecting()
+    {
+        $this->events->listen(ConfigureMail::class, function (ConfigureMail $event) {
+            $event->alwaysFrom($event->event->tenant->email, $event->event->tenant->name);
+        });
+    }
+
+    protected function assertAffected(Tenant $tenant)
+    {
+        $this->assertEquals(
+            $tenant->email,
+            $this->getAddressFromMessage($this->email)
+        );
+    }
+
+    protected function assertNotAffected(Tenant $tenant)
+    {
+        $this->assertNotEquals(
+            $tenant->email,
+            $this->getAddressFromMessage($this->email)
+        );
+    }
+
+    protected function afterIdentification(Tenant $tenant = null)
+    {
+        Mail::to('example@example.com')->send(new Mocks\Mail());
+    }
+
+    protected function registerForwardingCall()
+    {
+        //
+    }
+}

--- a/tests/unit/Affects/Mails/ConfigureMailNewTest.php
+++ b/tests/unit/Affects/Mails/ConfigureMailNewTest.php
@@ -30,6 +30,11 @@ class ConfigureMailNewTest extends AffectsTestCase
      */
     protected $forwardCallTest = false;
 
+    /**
+     * @var bool
+     */
+    protected $undoTest = false;
+
     protected $additionalProviders = [Provider::class];
 
     public $email;

--- a/tests/unit/Affects/Mails/ConfigureMailNewTest.php
+++ b/tests/unit/Affects/Mails/ConfigureMailNewTest.php
@@ -45,9 +45,10 @@ class ConfigureMailNewTest extends AffectsTestCase
 
     protected function getAddressFromMessage(Swift_Message $message = null)
     {
-        if(empty($message)){
+        if (empty($message)) {
             return '';
         }
+
         return array_keys($message->getFrom())[0];
     }
 

--- a/tests/unit/Affects/Mails/ConfigureMailTest.php
+++ b/tests/unit/Affects/Mails/ConfigureMailTest.php
@@ -29,7 +29,7 @@ class ConfigureMailTest extends TestCase
 
     protected $tenant;
 
-    public $emails = [];
+    public $email;
 
     protected function afterSetUp()
     {
@@ -57,11 +57,10 @@ class ConfigureMailTest extends TestCase
 
         Tenancy::getTenant();
         Mail::to('example@example.com')->send(new Mocks\Mail());
-        $email = array_shift($this->emails);
 
         $this->assertEquals(
             $this->tenant->email,
-            $this->getAddressFromMessage($email)
+            $this->getAddressFromMessage($this->email)
         );
     }
 
@@ -79,11 +78,11 @@ class ConfigureMailTest extends TestCase
 
         $this->environment->setTenant($first);
         Mail::to('example@example.com')->send(new Mocks\Mail());
-        $firstMail = array_shift($this->emails);
+        $firstMail = $this->email;
 
         $this->environment->setTenant($second);
         Mail::to('example@example.com')->send(new Mocks\Mail());
-        $secondMail = array_shift($this->emails);
+        $secondMail = $this->email;
 
         $this->assertNotEquals(
             $this->getAddressFromMessage($firstMail),

--- a/tests/unit/Affects/Mails/SwiftTestPlugin.php
+++ b/tests/unit/Affects/Mails/SwiftTestPlugin.php
@@ -35,7 +35,7 @@ class SwiftTestPlugin implements Swift_Events_SendListener
      */
     public function beforeSendPerformed(Swift_Events_SendEvent $evt)
     {
-        $this->test->emails[] = $evt->getMessage();
+        $this->test->email = $evt->getMessage();
     }
 
     /**

--- a/tests/unit/Affects/Routes/ConfiguresRoutesNewTest.php
+++ b/tests/unit/Affects/Routes/ConfiguresRoutesNewTest.php
@@ -18,9 +18,9 @@ namespace Tenancy\Tests\Affects\Routes;
 
 use Illuminate\Routing\Router;
 use Tenancy\Affects\Routes\Events\ConfigureRoutes;
-use Tenancy\Tests\Affects\AffectsTestCase;
 use Tenancy\Affects\Routes\Provider;
 use Tenancy\Identification\Contracts\Tenant;
+use Tenancy\Tests\Affects\AffectsTestCase;
 
 class ConfiguresRoutesNewTest extends AffectsTestCase
 {

--- a/tests/unit/Affects/Routes/ConfiguresRoutesNewTest.php
+++ b/tests/unit/Affects/Routes/ConfiguresRoutesNewTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Tenancy for Laravel & Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+
+namespace Tenancy\Tests\Affects\Routes;
+
+use Illuminate\Routing\Router;
+use Tenancy\Affects\Routes\Events\ConfigureRoutes;
+use Tenancy\Tests\Affects\AffectsTestCase;
+use Tenancy\Affects\Routes\Provider;
+use Tenancy\Identification\Contracts\Tenant;
+
+class ConfiguresRoutesNewTest extends AffectsTestCase
+{
+    /**
+     * @var bool
+     */
+    protected $forwardCallTest = false;
+
+    protected $additionalProviders = [Provider::class];
+
+    protected function registerAffecting()
+    {
+        $this->events->listen(ConfigureRoutes::class, function (ConfigureRoutes $event) {
+            $event->fromFile([], __DIR__.'/routes.php');
+        });
+    }
+
+    protected function assertAffected(Tenant $tenant)
+    {
+        $router = $this->app->make(Router::class);
+        $this->assertTrue($router->has('bar'));
+    }
+
+    protected function assertNotAffected(Tenant $tenant)
+    {
+        $router = $this->app->make(Router::class);
+        $this->assertFalse($router->has('bar'));
+    }
+}

--- a/tests/unit/Affects/URLs/ConfiguresURLTest.php
+++ b/tests/unit/Affects/URLs/ConfiguresURLTest.php
@@ -29,14 +29,14 @@ class ConfiguresURLTest extends AffectsTestCase
     protected function registerForwardingCall()
     {
         $this->events->listen(ConfigureURL::class, function (ConfigureURL $event) {
-            $event->forceRootUrl($event->event->tenant->name. '.tenant');
+            $event->forceRootUrl($event->event->tenant->name.'.tenant');
         });
     }
 
     protected function registerAffecting()
     {
         $this->events->listen(ConfigureURL::class, function (ConfigureURL $event) {
-            $event->changeRoot($event->event->tenant->name. '.tenant');
+            $event->changeRoot($event->event->tenant->name.'.tenant');
         });
     }
 
@@ -51,7 +51,7 @@ class ConfiguresURLTest extends AffectsTestCase
     protected function assertAffected(Tenant $tenant)
     {
         $this->assertEquals(
-            $tenant->name . '.tenant',
+            $tenant->name.'.tenant',
             URL::current()
         );
     }

--- a/tests/unit/Affects/URLs/ConfiguresURLTest.php
+++ b/tests/unit/Affects/URLs/ConfiguresURLTest.php
@@ -19,7 +19,7 @@ namespace Tenancy\Tests\Affects\URLs;
 use Illuminate\Support\Facades\URL;
 use Tenancy\Affects\URLs\Events\ConfigureURL;
 use Tenancy\Affects\URLs\Provider;
-use Tenancy\Testing\Mocks\Tenant;
+use Tenancy\Identification\Contracts\Tenant;
 use Tenancy\Tests\Affects\AffectsTestCase;
 
 class ConfiguresURLTest extends AffectsTestCase
@@ -40,10 +40,10 @@ class ConfiguresURLTest extends AffectsTestCase
         });
     }
 
-    protected function assertNotAffected()
+    protected function assertNotAffected(Tenant $tenant)
     {
-        $this->assertStringNotContainsString(
-            '.tenant',
+        $this->assertNotEquals(
+            $tenant->name . '.tenant',
             URL::current()
         );
     }

--- a/tests/unit/Affects/URLs/ConfiguresURLTest.php
+++ b/tests/unit/Affects/URLs/ConfiguresURLTest.php
@@ -43,7 +43,7 @@ class ConfiguresURLTest extends AffectsTestCase
     protected function assertNotAffected(Tenant $tenant)
     {
         $this->assertNotEquals(
-            $tenant->name . '.tenant',
+            $tenant->name.'.tenant',
             URL::current()
         );
     }

--- a/tests/unit/Affects/Views/ConfiguresViewsNewTest.php
+++ b/tests/unit/Affects/Views/ConfiguresViewsNewTest.php
@@ -19,8 +19,8 @@ namespace Tenancy\Tests\Affects\Views;
 use Illuminate\Contracts\View\Factory;
 use Tenancy\Affects\Views\Events\ConfigureViews;
 use Tenancy\Affects\Views\Provider;
-use Tenancy\Tests\Affects\AffectsTestCase;
 use Tenancy\Identification\Contracts\Tenant;
+use Tenancy\Tests\Affects\AffectsTestCase;
 
 class ConfiguresViewsNewTest extends AffectsTestCase
 {

--- a/tests/unit/Affects/Views/ConfiguresViewsNewTest.php
+++ b/tests/unit/Affects/Views/ConfiguresViewsNewTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Tenancy for Laravel & Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+
+namespace Tenancy\Tests\Affects\Views;
+
+use Illuminate\Contracts\View\Factory;
+use Tenancy\Affects\Views\Events\ConfigureViews;
+use Tenancy\Affects\Views\Provider;
+use Tenancy\Tests\Affects\AffectsTestCase;
+use Tenancy\Identification\Contracts\Tenant;
+
+class ConfiguresViewsNewTest extends AffectsTestCase
+{
+    /**
+     * @var bool
+     */
+    protected $forwardCallTest = false;
+
+    /**
+     * @var bool
+     */
+    protected $undoTest = false;
+
+    protected $additionalProviders = [Provider::class];
+
+    protected function registerAffecting()
+    {
+        $this->events->listen(ConfigureViews::class, function (ConfigureViews $event) {
+            $event->addNamespace(__DIR__.'/views/');
+        });
+    }
+
+    protected function assertAffected(Tenant $tenant)
+    {
+        /** @var Factory $views */
+        $views = $this->app->make(Factory::class);
+        $this->assertTrue($views->exists('tenant::test'));
+    }
+
+    protected function assertNotAffected(Tenant $tenant)
+    {
+        /** @var Factory $views */
+        $views = $this->app->make(Factory::class);
+        $this->assertFalse($views->exists('tenant::test'));
+    }
+}


### PR DESCRIPTION
By generalizing the tests like this, we achieve something that we also did with the DB tests:
- Being able to quickly add/remove Affects-wide tests.
- Knowing exactly what situations are tested across ALL affects.
- Easier testing with the "helper" functions that this adds.
- All tests will somewhat read the same.
- Drastically reduce actual testing code.