### PR TITLE
update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,17 +4,17 @@
     "keywords": ["laravel", "multi-tenant", "saas", "tenancy", "aws", "gce"],
     "license": "MIT",
     "require": {
-        "laravel/framework": "6.0.*",
+        "laravel/framework": "^6.0",
         "psr/container": "^1.0.0",
         "doctrine/dbal": "^2.9"
     },
     "require-dev": {
         "fzaninotto/faker": "^1.7",
-        "laravel/laravel": "6.0.*",
+        "laravel/laravel": "^6.0",
         "phpunit/phpunit": "^8.0",
         "mockery/mockery": "^1.0",
         "squizlabs/php_codesniffer": "^3.3",
-        "psalm/plugin-laravel": "^0.0.5",
+        "psalm/plugin-laravel": "^0.4",
         "zendframework/zend-diactoros": "^1.0"
     },
     "autoload": {

--- a/tests/unit/Affects/Filesystems/ConfiguresDiskTest.php
+++ b/tests/unit/Affects/Filesystems/ConfiguresDiskTest.php
@@ -56,7 +56,7 @@ class ConfiguresDiskTest extends TestCase
     public function configuration_initially_empty()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Driver [] is not supported.');
+        $this->expectExceptionMessage('Disk [tenant] does not have a configured driver.');
 
         $this->manager->disk('tenant');
     }


### PR DESCRIPTION
- Version 6.1.0 and 6.2.0 of `Laravel/framework` was recently released but our constraints did not allow for those versions
- Updated a dev depentencies to the latest version as well