### PR TITLE
Add Postgres database driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 composer.lock
 vendor/
 .tmp
+.idea/

--- a/build/tenancy-split.sh
+++ b/build/tenancy-split.sh
@@ -31,6 +31,7 @@ git subsplit publish --heads="master" src/Identification/Queue:git@github.com:te
 # Database drivers
 git subsplit publish --heads="master" src/Database/Mysql:git@github.com:tenancy/db-driver-mysql.git
 git subsplit publish --heads="master" src/Database/Sqlite:git@github.com:tenancy/db-driver-sqlite.git
+git subsplit publish --heads="master" src/Database/Postgres:git@github.com:tenancy/db-driver-postgres.git
 
 # Testing
 git subsplit publish --heads="master" src/Testing:git@github.com:tenancy/testing.git

--- a/src/Database/Postgres/Concerns/ManagesSystemConnection.php
+++ b/src/Database/Postgres/Concerns/ManagesSystemConnection.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Tenancy for Laravel
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+
+namespace Tenancy\Database\Drivers\Postgres\Concerns;
+
+interface ManagesSystemConnection
+{
+    /**
+     * Allows overriding the system connection used for the tenant.
+     *
+     * @return null|string
+     */
+    public function getManagingSystemConnection(): ?string;
+}

--- a/src/Database/Postgres/Driver/Postgres.php
+++ b/src/Database/Postgres/Driver/Postgres.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Tenancy for Laravel
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+
+namespace Tenancy\Database\Drivers\Postgres\Driver;
+
+use Closure;
+use Illuminate\Support\Facades\DB;
+use Tenancy\Identification\Contracts\Tenant;
+use Illuminate\Database\ConnectionInterface;
+use Tenancy\Hooks\Database\Events\Drivers as Events;
+use Tenancy\Hooks\Database\Contracts\ProvidesDatabase;
+use Tenancy\Database\Drivers\Postgres\Concerns\ManagesSystemConnection;
+
+class Postgres implements ProvidesDatabase
+{
+    public function configure(Tenant $tenant): array
+    {
+        $config = [];
+
+        event(new Events\Configuring($tenant, $config, $this));
+
+        return $config;
+    }
+
+    public function create(Tenant $tenant): bool
+    {
+        $config = $this->configure($tenant);
+
+        event(new Events\Creating($tenant, $config, $this));
+
+        return $this->processAndDispatch(Events\Created::class, $tenant, function (ConnectionInterface $db) use ($config) {
+            return $db->unprepared("CREATE USER \"{$config['username']}\" WITH PASSWORD '{$config['password']}'") &&
+                $db->unprepared("CREATE DATABASE \"{$config['database']}\" WITH OWNER \"{$config['username']}\"");
+        });
+    }
+
+    public function update(Tenant $tenant): bool
+    {
+        $config = $this->configure($tenant);
+
+        event(new Events\Updating($tenant, $config, $this));
+
+        if (!isset($config['oldUsername'])) {
+            return false;
+        }
+
+        return $this->processAndDispatch(Events\Updated::class, $tenant, function (ConnectionInterface $db) use ($config) {
+            return $db->unprepared("ALTER USER \"{$config['oldUsername']}\" RENAME TO \"{$config['username']}\"") &&
+                $db->unprepared("ALTER USER \"{$config['username']}\" PASSWORD '{$config['password']}'") &&
+                $db->unprepared("ALTER DATABASE \"{$config['oldUsername']}\" RENAME TO \"{$config['database']}\"");
+        });
+    }
+
+    public function delete(Tenant $tenant): bool
+    {
+        $config = $this->configure($tenant);
+
+        event(new Events\Deleting($tenant, $config, $this));
+
+        return $this->processAndDispatch(Events\Deleted::class, $tenant, function (ConnectionInterface $db) use ($config) {
+            return $db->unprepared(sprintf('DROP DATABASE IF EXISTS "%s"', $config['database'])) &&
+                $db->unprepared(sprintf('DROP USER "%s"', $config['username']));
+        });
+    }
+
+    /**
+     * Get the system database connection.
+     *
+     * @param  Tenant  $tenant
+     * @return ConnectionInterface
+     */
+    protected function system(Tenant $tenant): ConnectionInterface
+    {
+        $connection = null;
+
+        if ($tenant instanceof ManagesSystemConnection) {
+            $connection = $tenant->getManagingSystemConnection() ?? $connection;
+        }
+
+        return DB::connection($connection);
+    }
+
+    /**
+     * Processes the provided statements and dispatches an event.
+     *
+     * @param string $event
+     * @param Tenant $tenant
+     * @param Closure $callback
+     *
+     * @return bool
+     */
+    private function processAndDispatch(string $event, Tenant $tenant, Closure $callback)
+    {
+        $result = $callback($this->system($tenant));
+
+        event((new $event($tenant, $this, $result)));
+
+        return $result;
+    }
+}

--- a/src/Database/Postgres/Listeners/ConfiguresTenantDatabase.php
+++ b/src/Database/Postgres/Listeners/ConfiguresTenantDatabase.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Tenancy for Laravel
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+namespace Tenancy\Database\Drivers\Postgres\Listeners;
+
+use Tenancy\Database\Drivers\Postgres\Driver\Postgres;
+use Tenancy\Hooks\Database\Contracts\ProvidesDatabase;
+use Tenancy\Hooks\Database\Events\Resolving;
+
+class ConfiguresTenantDatabase
+{
+    public function handle(Resolving $resolving): ?ProvidesDatabase
+    {
+        return new Postgres();
+    }
+}

--- a/src/Database/Postgres/Provider.php
+++ b/src/Database/Postgres/Provider.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Tenancy for Laravel
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+
+namespace Tenancy\Database\Drivers\Postgres;
+
+use Tenancy\Hooks\Database\Support\DatabaseProvider;
+use Tenancy\Database\Drivers\Postgres\Listeners\ConfiguresTenantDatabase;
+
+class Provider extends DatabaseProvider
+{
+    protected $listener = ConfiguresTenantDatabase::class;
+}

--- a/src/Database/Postgres/composer.json
+++ b/src/Database/Postgres/composer.json
@@ -15,8 +15,8 @@
     "authors": [
         {
             "name": "Erik Gaal",
-            "email": "me@erikgaal.nl",
-        },
+            "email": "me@erikgaal.nl"
+        }
     ],
     "extra": {
         "laravel": {

--- a/src/Database/Postgres/composer.json
+++ b/src/Database/Postgres/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "tenancy/db-driver-postgres",
+    "description": "The tenancy/tenancy database driver for postgres",
+    "keywords": ["database", "tenancy", "postgres"],
+    "license": "MIT",
+    "require": {
+        "tenancy/framework": "*",
+        "tenancy/hooks-database": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "Tenancy\\Database\\Drivers\\Postgres\\": ""
+        }
+    },
+    "authors": [
+        {
+            "name": "Erik Gaal",
+            "email": "me@erikgaal.nl",
+        },
+    ],
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Tenancy\\Database\\Drivers\\Postgres\\Provider"
+            ]
+        }
+    }
+}

--- a/src/Database/Postgres/license.md
+++ b/src/Database/Postgres/license.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Tenancy for Laravel & Erik Gaal <me@erikgaal.nl>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tests/Database/Postgres/Feature/PostgresConnectionDriverTest.php
+++ b/tests/Database/Postgres/Feature/PostgresConnectionDriverTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Tenancy for Laravel
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+
+namespace Tenancy\Tests\Database\Postgres\Feature;
+
+use Doctrine\DBAL\Driver\PDOException;
+use Tenancy\Database\Drivers\Postgres\Provider;
+use Tenancy\Tests\Mocks\Tenants\PostgresTenant;
+use Tenancy\Tests\Database\DatabaseFeatureTestCase;
+use Tenancy\Tests\UsesConnections;
+use Tenancy\Tests\UsesTenants;
+
+class PostgresConnectionDriverTest extends DatabaseFeatureTestCase
+{
+    use UsesTenants;
+    use UsesConnections;
+
+    protected $additionalProviders = [Provider::class];
+
+    protected $exception = PDOException::class;
+
+    protected $tenantModel = PostgresTenant::class;
+
+    protected function afterSetUp()
+    {
+        $this->registerFactories();
+        parent::afterSetUp();
+    }
+
+    protected function registerDatabaseListener()
+    {
+        config(['database.connections.pgsql' => include $this->getPostgresConfigurationPath()]);
+
+        $this->configureBoth(function ($event) {
+            $event->useConnection('pgsql', $event->configuration);
+        });
+    }
+}

--- a/tests/Mocks/Connections/postgres.php
+++ b/tests/Mocks/Connections/postgres.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Tenancy for Laravel
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+
+return [
+    'driver'         => 'pgsql',
+    'host'           => env('TENANCY_HOST', '127.0.0.1'),
+    'port'           => env('DB_PORT', '5432'),
+    'database'       => env('TENANCY_DB', 'testing'),
+    'username'       => env('TENANCY_USERNAME', 'testing'),
+    'password'       => env('TENANCY_PASSWORD', ''),
+    'charset'        => 'utf8',
+    'prefix'         => '',
+    'prefix_indexes' => true,
+    'schema'         => 'public',
+    'sslmode'        => 'prefer',
+];

--- a/tests/Mocks/Tenants/PostgresTenant.php
+++ b/tests/Mocks/Tenants/PostgresTenant.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the tenancy/tenancy package.
+ *
+ * Copyright Tenancy for Laravel
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/tenancy
+ */
+
+namespace Tenancy\Tests\Mocks\Tenants;
+
+use Tenancy\Database\Drivers\Postgres\Concerns\ManagesSystemConnection;
+use Tenancy\Testing\Mocks\Tenant;
+
+class PostgresTenant extends Tenant implements ManagesSystemConnection
+{
+    public function getManagingSystemConnection(): ?string
+    {
+        return 'pgsql';
+    }
+}

--- a/tests/Mocks/Tenants/factories/MultiFactory.php
+++ b/tests/Mocks/Tenants/factories/MultiFactory.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 use Faker\Generator as Faker;
 use Tenancy\Tests\Mocks\Tenants\MysqlTenant;
+use Tenancy\Tests\Mocks\Tenants\PostgresTenant;
 use Tenancy\Tests\Mocks\Tenants\NullConsoleTenant;
 use Tenancy\Tests\Mocks\Tenants\NullEnvironmentTenant;
 use Tenancy\Tests\Mocks\Tenants\NullHttpTenant;
@@ -36,6 +37,7 @@ use Tenancy\Tests\Mocks\Tenants\SimpleQueueTenant;
 */
 foreach ([
     MysqlTenant::class,
+    PostgresTenant::class,
     NullConsoleTenant::class,
     NullEnvironmentTenant::class,
     NullHttpTenant::class,

--- a/tests/UsesConnections.php
+++ b/tests/UsesConnections.php
@@ -41,4 +41,16 @@ trait UsesConnections
             .DIRECTORY_SEPARATOR.'Connections'
             .DIRECTORY_SEPARATOR.'mysql.php';
     }
+
+    /**
+     * Gets the path to the postgres database configuration.
+     *
+     * @return string
+     */
+    protected function getPostgresConfigurationPath()
+    {
+        return __DIR__.DIRECTORY_SEPARATOR.'Mocks'
+            .DIRECTORY_SEPARATOR.'Connections'
+            .DIRECTORY_SEPARATOR.'postgres.php';
+    }
 }


### PR DESCRIPTION
There are some things left to discuss.

- [ ] There is a duplicate of the `ManagesSystemConnection` interface in both `Mysql` and `Postgres` namespaces now. Is this okay?

- [ ] I didn't really like the non-typed way of sending query statements as strings in `scr/Database/Mysql/Driver/Mysql.php`, so instead in this implementation, you pass a Closure that has the `connection` object as a parameter.

- [ ] To fix the tests, should we add the Postgres service, or should we find a more robust way of running a subset of tasks in multiple jobs?

Anyway, looking forward to your feedback!