### PR TITLE
Autoload Tenancy\Testing when using tenancy/tenancy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
             "Tenancy\\Affects\\": "src/Affects",
             "Tenancy\\Database\\Drivers\\": "src/Database",
             "Tenancy\\Hooks\\": "src/Hooks",
-            "Tenancy\\Identification\\Drivers\\": "src/Identification"
+            "Tenancy\\Identification\\Drivers\\": "src/Identification",
+            "Tenancy\\Testing\\": "src/Testing"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Tenancy\\Testing\\": "src/Testing",
             "Tenancy\\Tests\\": "tests/",
             "Tenancy\\Tests\\Framework\\": "tests/Tenancy",
             "Tenancy\\Tests\\Affects\\": "tests/Affects",


### PR DESCRIPTION
When using the `tenancy/tenancy` package instead of separate packages, the `Tenancy/Testing` namespace isn't autoloaded and causes the testing utilities to not be usable.

```php
use Tenancy\Testing\TestCase;

class ExampleTest extends TestCase
{
	// Some tests here
}

// PHP Fatal error:  Uncaught Error: Class 'Tenancy\Testing\TestCase' not found in ...
```