### PR TITLE
Use '%' host when creating users

### DIFF
--- a/tests/Database/Mysql/Feature/MysqlConnectionDriverTest.php
+++ b/tests/Database/Mysql/Feature/MysqlConnectionDriverTest.php
@@ -46,6 +46,10 @@ class MysqlConnectionDriverTest extends DatabaseFeatureTestCase
 
         $this->configureBoth(function ($event) {
             $event->useConnection('mysql', $event->configuration);
+
+            if($event instanceof \Tenancy\Hooks\Database\Events\Drivers\Configuring) {
+                $event->configuration['host'] = '%';
+            }
         });
     }
 }

--- a/tests/Database/Mysql/Feature/MysqlConnectionDriverTest.php
+++ b/tests/Database/Mysql/Feature/MysqlConnectionDriverTest.php
@@ -47,7 +47,7 @@ class MysqlConnectionDriverTest extends DatabaseFeatureTestCase
         $this->configureBoth(function ($event) {
             $event->useConnection('mysql', $event->configuration);
 
-            if($event instanceof \Tenancy\Hooks\Database\Events\Drivers\Configuring) {
+            if ($event instanceof \Tenancy\Hooks\Database\Events\Drivers\Configuring) {
                 $event->configuration['host'] = '%';
             }
         });

--- a/tests/Database/Mysql/Feature/MysqlConnectionDriverTest.php
+++ b/tests/Database/Mysql/Feature/MysqlConnectionDriverTest.php
@@ -18,6 +18,7 @@ namespace Tenancy\Tests\Database\Mysql\Feature;
 
 use Doctrine\DBAL\Driver\PDOException;
 use Tenancy\Database\Drivers\Mysql\Provider;
+use Tenancy\Hooks\Database\Events\Drivers\Configuring;
 use Tenancy\Tests\Database\DatabaseFeatureTestCase;
 use Tenancy\Tests\Mocks\Tenants\MysqlTenant;
 use Tenancy\Tests\UsesConnections;
@@ -47,7 +48,7 @@ class MysqlConnectionDriverTest extends DatabaseFeatureTestCase
         $this->configureBoth(function ($event) {
             $event->useConnection('mysql', $event->configuration);
 
-            if ($event instanceof \Tenancy\Hooks\Database\Events\Drivers\Configuring) {
+            if ($event instanceof Configuring) {
                 $event->configuration['host'] = '%';
             }
         });


### PR DESCRIPTION
When running tests locally against a containerized database, mysql tests will fail since it's looking for a host of 127.0.0.1 instead of 172.17.0.1 (for example).  Using the wildcard host will allow this to work, while having minimal (if any) effect on anything else.