### PR TITLE
Replace abandoned package.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "mockery/mockery": "^1.0",
         "squizlabs/php_codesniffer": "^3.3",
         "psalm/plugin-laravel": "^1.1",
-        "zendframework/zend-diactoros": "^1.0"
+        "laminas/laminas-diactoros": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "mockery/mockery": "^1.0",
         "squizlabs/php_codesniffer": "^3.3",
         "psalm/plugin-laravel": "^1.1",
-        "laminas/laminas-diactoros": "^2.0"
+        "laminas/laminas-diactoros": "^1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I noticed a warning when running composer update that the zend package is abandoned and to use this one instead.  I didn't do any significant testing, so the version was a shot-in-the-dark.