### PR TITLE
fix: correct return value for queue()

### DIFF
--- a/src/Tenancy/Lifecycle/ConfigurableHook.php
+++ b/src/Tenancy/Lifecycle/ConfigurableHook.php
@@ -36,7 +36,7 @@ abstract class ConfigurableHook extends Hook
 
     public function queue(): ?string
     {
-        return $this->queue;
+        return $this->queue ?: null;
     }
 
     public function priority(): int


### PR DESCRIPTION
The method signature says `?string` but the value by default is `false.

With strict_types enabled this shouldn't even beable to run.

This is the problem in its simplest form:

```php
<?php

declare(strict_types=1);

class Test
{
    public $queue = false;

    public function queue(): ?string
    {
        return $this->queue;
    }
}

var_dump((new Test)->queue());
```

http://sandbox.onlinephpfunctions.com/code/2ef803024e9fe1d9a001985bec5973269cc9b083