### PR TITLE
Fixed Horizon issue by binding to resolving instead of extending

### DIFF
--- a/src/Identification/Queue/Providers/IdentificationProvider.php
+++ b/src/Identification/Queue/Providers/IdentificationProvider.php
@@ -29,14 +29,12 @@ class IdentificationProvider extends DriverProvider
 
     public function boot()
     {
-        $this->app->extend('queue', function (QueueManager $queue) {
+        $this->app->resolving(QueueManager::class, function ($queue) {
             // Store tenant key and identifier on job payload when a tenant is identified.
             $queue->createPayloadUsing($this->app->make(Middleware\SaveTenantOnQueuePayload::class));
 
             // Resolve any tenant related meta data on job and allow resolving of tenant.
             $queue->before($this->app->make(Middleware\ReadTenantFromQueuePayload::class));
-
-            return $queue;
         });
     }
 }

--- a/src/Identification/Queue/Providers/IdentificationProvider.php
+++ b/src/Identification/Queue/Providers/IdentificationProvider.php
@@ -34,7 +34,9 @@ class IdentificationProvider extends DriverProvider
             $queue->createPayloadUsing($this->app->make(Middleware\SaveTenantOnQueuePayload::class));
 
             // Resolve any tenant related meta data on job and allow resolving of tenant.
-            $queue->before($this->app->make(Middleware\ReadTenantFromQueuePayload::class));
+            //$queue->before($this->app->make(Middleware\ReadTenantFromQueuePayload::class));
         });
+
+        $this->app['queue']->before($this->app->make(Middleware\ReadTenantFromQueuePayload::class));
     }
 }

--- a/src/Identification/Queue/Providers/IdentificationProvider.php
+++ b/src/Identification/Queue/Providers/IdentificationProvider.php
@@ -29,16 +29,10 @@ class IdentificationProvider extends DriverProvider
 
     public function boot()
     {
-        // $this->app->resolving(QueueManager::class, function ($queue) {
-        //     // Store tenant key and identifier on job payload when a tenant is identified.
-        //     $queue->createPayloadUsing($this->app->make(Middleware\SaveTenantOnQueuePayload::class));
-
-        //     // Resolve any tenant related meta data on job and allow resolving of tenant.
-        //     //$queue->before($this->app->make(Middleware\ReadTenantFromQueuePayload::class));
-        // });
-
+        // Store tenant key and identifier on job payload when a tenant is identified.
         \Queue::createPayloadUsing($this->app->make(Middleware\SaveTenantOnQueuePayload::class));
 
+        // Resolve any tenant related meta data on job and allow resolving of tenant.
         \Queue::before($this->app->make(Middleware\ReadTenantFromQueuePayload::class));
     }
 }

--- a/src/Identification/Queue/Providers/IdentificationProvider.php
+++ b/src/Identification/Queue/Providers/IdentificationProvider.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Tenancy\Identification\Drivers\Queue\Providers;
 
-use Illuminate\Queue\QueueManager;
 use Tenancy\Identification\Drivers\Queue\Contracts\IdentifiesByQueue;
 use Tenancy\Identification\Drivers\Queue\Middleware;
 use Tenancy\Support\DriverProvider;

--- a/src/Identification/Queue/Providers/IdentificationProvider.php
+++ b/src/Identification/Queue/Providers/IdentificationProvider.php
@@ -29,14 +29,16 @@ class IdentificationProvider extends DriverProvider
 
     public function boot()
     {
-        $this->app->resolving(QueueManager::class, function ($queue) {
-            // Store tenant key and identifier on job payload when a tenant is identified.
-            $queue->createPayloadUsing($this->app->make(Middleware\SaveTenantOnQueuePayload::class));
+        // $this->app->resolving(QueueManager::class, function ($queue) {
+        //     // Store tenant key and identifier on job payload when a tenant is identified.
+        //     $queue->createPayloadUsing($this->app->make(Middleware\SaveTenantOnQueuePayload::class));
 
-            // Resolve any tenant related meta data on job and allow resolving of tenant.
-            //$queue->before($this->app->make(Middleware\ReadTenantFromQueuePayload::class));
-        });
+        //     // Resolve any tenant related meta data on job and allow resolving of tenant.
+        //     //$queue->before($this->app->make(Middleware\ReadTenantFromQueuePayload::class));
+        // });
 
-        $this->app['queue']->before($this->app->make(Middleware\ReadTenantFromQueuePayload::class));
+        \Queue::createPayloadUsing($this->app->make(Middleware\SaveTenantOnQueuePayload::class));
+
+        \Queue::before($this->app->make(Middleware\ReadTenantFromQueuePayload::class));
     }
 }


### PR DESCRIPTION
Fixes issue `Call to undefined method Illuminate\Queue\RedisQueue::readyNow()` with Laraven Horizon


Original issue here:
https://github.com/tenancy/multi-tenant/commit/e0a564356e0d97e8f301953712deb0e8e4650d88#comments