### PR TITLE
Include identification-driver-queue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,8 @@
         "tenancy/db-driver-sqlite": "self.version",
         "tenancy/identification-driver-console": "self.version",
         "tenancy/identification-driver-environment": "self.version",
-        "tenancy/identification-driver-http": "self.version"
+        "tenancy/identification-driver-http": "self.version",
+        "tenancy/identification-driver-queue": "self.version"
     },
     "funding": [
         {


### PR DESCRIPTION
Add `tenancy/identification-driver-queue` into the replace composer config.

Resolves #182 