### PR TITLE
Fix isIdentified still true even when executing Tenancy::setTenant(null)

### DIFF
--- a/src/Tenancy/Environment.php
+++ b/src/Tenancy/Environment.php
@@ -44,9 +44,7 @@ class Environment
 
         $this->events()->dispatch(new Switched($tenant));
 
-        if (!$this->identified) {
-            $this->identified = true;
-        }
+        $this->identified = !is_null($tenant);
 
         return $this;
     }


### PR DESCRIPTION
The identified flag was still true, even after resetting the tenant
Eg:

```php
Tenancy::setTenant($someTenant);
Tenancy::isIdentified(); //true
Tenancy::setTenant(null);
Tenancy::isIdentified(); //Still true but should be false
```

Note that it is also possible to compute this on the fly using the value of $this->tenant rather than having a separate flag/variable for it but that would mean removing the setIdentified method, so I didn't include it in this PR