### PR TITLE
Add commit message keyword to disable running tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
                       db: MySQL5
                     - service: mariadb
                       db: MariaDB
-                
+
                 exclude:
                   - laravel: 8.*
                     php: 7.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
 jobs:
     test:
         runs-on: ubuntu-latest
+        if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
         strategy:
             fail-fast: false


### PR DESCRIPTION
Closes tenancy/ideas#20

contains() is natively case-insensitive (https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contains), so no worries there.

Must use `[skip-ci]`, not `[ci-skip]`