### PR TITLE
[1.x] Allow the user to manage the migrations better

### DIFF
--- a/src/Hooks/Migration/Events/ConfigureMigrations.php
+++ b/src/Hooks/Migration/Events/ConfigureMigrations.php
@@ -39,7 +39,14 @@ class ConfigureMigrations
 
     public function path(string $path)
     {
-        $this->hook->migrator->path($path);
+        $this->hook->path($path);
+
+        return $this;
+    }
+
+    public function setPaths(array $paths)
+    {
+        $this->hook->setPaths($paths);
 
         return $this;
     }

--- a/src/Hooks/Migration/Hooks/MigratesHook.php
+++ b/src/Hooks/Migration/Hooks/MigratesHook.php
@@ -30,6 +30,8 @@ class MigratesHook extends ConfigurableHook
      */
     public $migrator;
 
+    public $paths = [];
+
     public $connection;
 
     public $action;
@@ -39,6 +41,7 @@ class MigratesHook extends ConfigurableHook
     public function __construct()
     {
         $this->migrator = resolve('migrator');
+        $this->paths = $this->migrator->paths();
         $this->connection = Tenancy::getTenantConnectionName();
         $this->resolver = resolve(ResolvesConnections::class);
     }
@@ -65,9 +68,19 @@ class MigratesHook extends ConfigurableHook
         if (!$this->migrator->repositoryExists()) {
             $this->migrator->getRepository()->createRepository();
         }
-        call_user_func([$this->migrator, $this->action], $this->migrator->paths());
+        call_user_func([$this->migrator, $this->action], $this->paths);
 
         $this->resolver->__invoke(null, $this->connection);
         $db->setDefaultConnection($default);
+    }
+
+    public function path(string $path)
+    {
+        $this->paths[] = $path;
+    }
+
+    public function setPaths(array $paths)
+    {
+        $this->paths = $paths;
     }
 }

--- a/tests/Hooks/Migration/Unit/ConfiguresMigrationsTest.php
+++ b/tests/Hooks/Migration/Unit/ConfiguresMigrationsTest.php
@@ -43,7 +43,7 @@ class ConfiguresMigrationsTest extends ConfigureHookTestCase
 
         $this->assertContains(
             __DIR__,
-            $this->hook->migrator->paths()
+            $this->hook->paths
         );
     }
 }


### PR DESCRIPTION
Allows for users to manage the migrations better.
They can now completely empty the migrations array, getting rid of the migrations registered by other packages etc.