### PR TITLE
[1.x] Add flush method to ConfigureMigrations and stores configured paths locally to the MigratesHook

### DIFF
--- a/src/Hooks/Migration/Events/ConfigureMigrations.php
+++ b/src/Hooks/Migration/Events/ConfigureMigrations.php
@@ -39,7 +39,14 @@ class ConfigureMigrations
 
     public function path(string $path)
     {
-        $this->hook->migrator->path($path);
+        $this->hook->paths[] = $path;
+
+        return $this;
+    }
+
+    public function flush()
+    {
+        $this->hook->paths = [];
 
         return $this;
     }

--- a/src/Hooks/Migration/Hooks/MigratesHook.php
+++ b/src/Hooks/Migration/Hooks/MigratesHook.php
@@ -36,11 +36,16 @@ class MigratesHook extends ConfigurableHook
 
     public $priority = -50;
 
+    /** @var array */
+    public $paths;
+
     public function __construct()
     {
         $this->migrator = resolve('migrator');
         $this->connection = Tenancy::getTenantConnectionName();
         $this->resolver = resolve(ResolvesConnections::class);
+
+        $this->paths = $this->migrator->paths();
     }
 
     public function for($event)
@@ -65,7 +70,7 @@ class MigratesHook extends ConfigurableHook
         if (!$this->migrator->repositoryExists()) {
             $this->migrator->getRepository()->createRepository();
         }
-        call_user_func([$this->migrator, $this->action], $this->migrator->paths());
+        call_user_func([$this->migrator, $this->action], $this->paths);
 
         $this->resolver->__invoke(null, $this->connection);
         $db->setDefaultConnection($default);

--- a/tests/Hooks/Migration/Unit/ConfiguresMigrationsTest.php
+++ b/tests/Hooks/Migration/Unit/ConfiguresMigrationsTest.php
@@ -63,7 +63,7 @@ class ConfiguresMigrationsTest extends ConfigureHookTestCase
             __DIR__,
             $this->hook->paths
         );
-        
+
         $this->events->listen($this->eventClass, function ($event) {
             $event->flush();
         });

--- a/tests/Hooks/Migration/Unit/ConfiguresMigrationsTest.php
+++ b/tests/Hooks/Migration/Unit/ConfiguresMigrationsTest.php
@@ -29,6 +29,12 @@ class ConfiguresMigrationsTest extends ConfigureHookTestCase
 
     protected $eventClass = ConfigureMigrations::class;
 
+    protected function afterSetUp()
+    {
+        resolve('migrator')->path(__DIR__);
+        parent::afterSetUp();
+    }
+
     /**
      * @dataProvider tenantEventsProvider
      *
@@ -36,14 +42,37 @@ class ConfiguresMigrationsTest extends ConfigureHookTestCase
     public function it_can_add_paths_to_the_migrator($tenantEvent)
     {
         $this->events->listen($this->eventClass, function ($event) {
-            $event->path(__DIR__);
+            $event->path(realpath(__DIR__.'/..'));
         });
 
         $this->hook->for(new $tenantEvent($this->mockTenant()));
 
         $this->assertContains(
+            realpath(__DIR__.'/..'),
+            $this->hook->paths
+        );
+    }
+
+    /**
+     * @dataProvider tenantEventsProvider
+     *
+     * @test */
+    public function it_can_clear_paths_from_the_migrator($tenantEvent)
+    {
+        $this->assertContains(
             __DIR__,
-            $this->hook->migrator->paths()
+            $this->hook->paths
+        );
+        
+        $this->events->listen($this->eventClass, function ($event) {
+            $event->flush();
+        });
+
+        $this->hook->for(new $tenantEvent($this->mockTenant()));
+
+        $this->assertNotContains(
+            __DIR__,
+            $this->hook->paths
         );
     }
 }

--- a/tests/Hooks/Migration/Unit/MigratesHookTest.php
+++ b/tests/Hooks/Migration/Unit/MigratesHookTest.php
@@ -29,6 +29,7 @@ class MigratesHookTest extends TestCase
 
     protected function afterSetUp()
     {
+        resolve('migrator')->path(__DIR__);
         $this->hook = $this->app->make(MigratesHook::class);
     }
 
@@ -37,6 +38,15 @@ class MigratesHookTest extends TestCase
     {
         $this->assertTrue(
             $this->hook->fires
+        );
+    }
+
+    /** @test */
+    public function it_initializes_paths_correctly()
+    {
+        $this->assertContains(
+            __DIR__,
+            $this->hook->paths
         );
     }
 


### PR DESCRIPTION
Same changes from the `1.1-dev` branch.

I haven't tested this locally, but I don't believe there's anything specific to 1.1 changes

Closes #208