### PR TITLE
[1.x] PHP 8 Support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
                     - php: 7.4
                       experimental: true
                     - php: 8.0
-                      experimental: false
+                      experimental: true
 
         services:
             mysql:

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "doctrine/dbal": "^2.9"
     },
     "require-dev": {
-        "fzaninotto/faker": "^1.9",
+        "fakerphp/faker": "^1.9",
         "laravel/laravel": "*",
         "phpunit/phpunit": "^8.0",
         "mockery/mockery": "^1.3"

--- a/src/Database/Mysql/Driver/Mysql.php
+++ b/src/Database/Mysql/Driver/Mysql.php
@@ -52,7 +52,7 @@ class Mysql implements ProvidesDatabase
         event(new Events\Creating($tenant, $config, $this));
 
         $result = $this->queryManager->setConnection($this->system($tenant))
-            ->processTransaction(function () use ($config) {
+            ->process(function () use ($config) {
                 $this->statement("CREATE USER IF NOT EXISTS `{$config['username']}`@'{$config['host']}' IDENTIFIED BY '{$config['password']}'");
                 $this->statement("CREATE DATABASE `{$config['database']}`");
                 $this->statement("GRANT ALL ON `{$config['database']}`.* TO `{$config['username']}`@'{$config['host']}'");
@@ -77,7 +77,7 @@ class Mysql implements ProvidesDatabase
         $tables = $this->retrieveTables($tenant);
 
         $result = $this->queryManager->setConnection($this->system($tenant))
-            ->processTransaction(function () use ($config, $tables) {
+            ->process(function () use ($config, $tables) {
                 $this->statement("RENAME USER `{$config['oldUsername']}`@'{$config['host']}' TO `{$config['username']}`@'{$config['host']}'");
                 $this->statement("ALTER USER `{$config['username']}`@`{$config['host']}` IDENTIFIED BY '{$config['password']}'");
                 $this->statement("CREATE DATABASE `{$config['database']}`");
@@ -104,7 +104,7 @@ class Mysql implements ProvidesDatabase
         event(new Events\Deleting($tenant, $config, $this));
 
         $result = $this->queryManager->setConnection($this->system($tenant))
-            ->processTransaction(function () use ($config) {
+            ->process(function () use ($config) {
                 $this->statement("DROP USER `{$config['username']}`@'{$config['host']}'");
                 $this->statement("DROP DATABASE IF EXISTS `{$config['database']}`");
             })


### PR DESCRIPTION
- Do not use MySQL Transaction anymore as it's actually not useful, this never properly worked as intended by the developers.
- Do not make PHP8 experimental anymore as it has a full release
- Replace `fzaninotto/faker` with `fakerphp/faker` as the package has been deprecated and found a new home due to some awesome maintainers