### PR TITLE
Provide old tenant in switched event

### DIFF
--- a/src/Tenancy/Environment.php
+++ b/src/Tenancy/Environment.php
@@ -35,9 +35,11 @@ class Environment
 
     public function setTenant(Tenant $tenant = null): static
     {
+        $oldTenant = $this->tenant;
+
         $this->tenant = $tenant;
 
-        $this->events()->dispatch(new Switched($tenant));
+        $this->events()->dispatch(new Switched($tenant, $oldTenant));
 
         if (!$this->identified) {
             $this->identified = true;

--- a/src/Tenancy/Identification/Events/Switched.php
+++ b/src/Tenancy/Identification/Events/Switched.php
@@ -21,7 +21,8 @@ use Tenancy\Identification\Contracts\Tenant;
 class Switched
 {
     public function __construct(
-        public ?Tenant $tenant = null
+        public ?Tenant $tenant = null,
+        public ?Tenant $oldTenant = null
     ) {
     }
 }

--- a/tests/Framework/Feature/Identification/TenantIdentificationEventsTest.php
+++ b/tests/Framework/Feature/Identification/TenantIdentificationEventsTest.php
@@ -46,6 +46,31 @@ class TenantIdentificationEventsTest extends TestCase
     }
 
     /** @test */
+    public function old_tenant_in_switched()
+    {
+        $oldTenant = null;
+        $this->events->listen(Switched::class, function (Switched $switched) use (&$newTenant, &$oldTenant) {
+            $newTenant = $switched->tenant;
+            $oldTenant = $switched->oldTenant;
+        });
+
+        $tenant1 = $this->mockTenant();
+        $tenant2 = $this->mockTenant();
+
+        $this->assertNotEquals($tenant1, $tenant2);
+
+        $this->environment->setTenant($tenant1);
+
+        $this->assertNull($oldTenant);
+        $this->assertEquals($tenant1, $newTenant);
+
+        $this->environment->setTenant($tenant2);
+
+        $this->assertEquals($tenant1, $oldTenant);
+        $this->assertEquals($tenant2, $newTenant);
+    }
+
+    /** @test */
     public function empty_tenant_is_resolved()
     {
         $switched = $resolving = $resolved = $nothingIdentified = $identified = 0;


### PR DESCRIPTION
It's quite a useful information to have in the switched event (if we need to unregister some stuff the previous tenant registered)

Without it we need to statically cache this information in any class that needs it