### PR TITLE
Bug: Make sure the tenant connection is not used for moving tables

### DIFF
--- a/src/Database/Mysql/Driver/Mysql.php
+++ b/src/Database/Mysql/Driver/Mysql.php
@@ -19,6 +19,7 @@ namespace Tenancy\Database\Drivers\Mysql\Driver;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Tenancy\Affects\Connections\Contracts\ResolvesConnections;
 use Tenancy\Database\Drivers\Mysql\Concerns\ManagesSystemConnection;
 use Tenancy\Facades\Tenancy;
@@ -136,13 +137,15 @@ class Mysql implements ProvidesDatabase
         $tempTenant = $tenant->replicate();
         $tempTenant->{$tenant->getTenantKeyName()} = $tenant->getOriginal($tenant->getTenantKeyName());
 
+        $tempConnectionName = Str::random(16);
+
         /** @var ResolvesConnections $resolver */
         $resolver = resolve(ResolvesConnections::class);
-        $resolver($tempTenant, Tenancy::getTenantConnectionName());
+        $resolver($tempTenant, $tempConnectionName);
 
-        $tables = Tenancy::getTenantConnection()->getDoctrineSchemaManager()->listTableNames();
+        $tables = DB::connection($tempConnectionName)->getDoctrineSchemaManager()->listTableNames();
 
-        $resolver(null, Tenancy::getTenantConnectionName());
+        $resolver(null, $tempConnectionName);
 
         return $tables;
     }

--- a/src/Database/Mysql/Driver/Mysql.php
+++ b/src/Database/Mysql/Driver/Mysql.php
@@ -22,7 +22,6 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Tenancy\Affects\Connections\Contracts\ResolvesConnections;
 use Tenancy\Database\Drivers\Mysql\Concerns\ManagesSystemConnection;
-use Tenancy\Facades\Tenancy;
 use Tenancy\Hooks\Database\Contracts\ProvidesDatabase;
 use Tenancy\Hooks\Database\Events\Drivers as Events;
 use Tenancy\Hooks\Database\Support\QueryManager;


### PR DESCRIPTION
Fixes #239

Short explanation:
In order to move the tables of the tenant to the right database (if the database was updated), we would instantiate a temporary connection on the specified TenantConnectionName. This would override the current tenant connection. Then we would empty that connection as we want to make sure we do not leave the connection open as it would form a security risk. Resulting in there not being a Tenant Connection anymore.

This fix simply uses a completely random connection name.