### PR TITLE
Update GHA dependencies and add Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/subsplit.yml
+++ b/.github/workflows/subsplit.yml
@@ -13,7 +13,7 @@ jobs:
 
         steps:
             - uses: actions/checkout@master
-            - uses: webfactory/ssh-agent@v0.4.1
+            - uses: webfactory/ssh-agent@v0.7.0
               with:
                 ssh-private-key: ${{ secrets.SUBSPLIT_KEY }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,14 +27,14 @@ jobs:
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Login to DockerHub
-              uses: docker/login-action@v1
+              uses: docker/login-action@v2
+              if: ${{ env.DOCKERHUB_USERNAME != null && env.DOCKERHUB_TOKEN != null }}
               with:
                 username: ${{ env.DOCKERHUB_USERNAME }}
                 password: ${{ env.DOCKERHUB_TOKEN }}
-              if: ${{ env.DOCKERHUB_USERNAME != null && env.DOCKERHUB_TOKEN != null }}
 
             - name: Run tests
               run: ./test --php ${{ matrix.php }} --laravel ${{ matrix.laravel }} --db ${{ matrix.service }} --dependencies ${{ matrix.dependency-version }}


### PR DESCRIPTION
- We're getting warnings on some builds due to old versions of a few actions
- Dependabot is a great tool provided by GitHub that allows us to automatically get PRs for GitHub Actions