### PR TITLE
Allow users to specify the old database themselves using current default logic

### DIFF
--- a/src/Affects/Connections/Events/Drivers/Configuring.php
+++ b/src/Affects/Connections/Events/Drivers/Configuring.php
@@ -60,10 +60,11 @@ class Configuring
 
         if ($tenant->isDirty($tenant->getTenantKeyName())) {
             $configuration['oldUsername'] = $tenant->getOriginal($tenant->getTenantKeyName());
+            $configuration['oldDatabase'] = $tenant->getOriginal($tenant->getTenantKeyName());
         }
 
         $configuration['username'] = $tenant->getTenantKey();
-        $configuration['database'] = $configuration['username'];
+        $configuration['database'] = $tenant->getTenantKey();
         $configuration['password'] = resolve(ProvidesPassword::class)->__invoke($tenant);
 
         return $configuration;

--- a/src/Database/Mysql/Driver/Mysql.php
+++ b/src/Database/Mysql/Driver/Mysql.php
@@ -70,7 +70,7 @@ class Mysql implements ProvidesDatabase
 
         event(new Events\Updating($tenant, $config, $this));
 
-        if (!isset($config['oldUsername'])) {
+        if (!isset($config['oldUsername']) && !isset($config['oldDatabase'])) {
             return false;
         }
 

--- a/src/Database/Mysql/Driver/Mysql.php
+++ b/src/Database/Mysql/Driver/Mysql.php
@@ -84,11 +84,11 @@ class Mysql implements ProvidesDatabase
                 $this->statement("GRANT ALL ON `{$config['database']}`.* TO `{$config['username']}`@'{$config['host']}'");
 
                 foreach ($tables as $table) {
-                    $this->statement("RENAME TABLE `{$config['oldUsername']}`.{$table} TO `{$config['database']}`.{$table}");
+                    $this->statement("RENAME TABLE `{$config['oldDatabase']}`.{$table} TO `{$config['database']}`.{$table}");
                 }
 
                 // Add database drop statement as last statement
-                $this->statement("DROP DATABASE `{$config['oldUsername']}`");
+                $this->statement("DROP DATABASE `{$config['oldDatabase']}`");
             })
             ->getStatus();
 

--- a/src/Hooks/Database/Events/Drivers/Configuring.php
+++ b/src/Hooks/Database/Events/Drivers/Configuring.php
@@ -60,10 +60,11 @@ class Configuring
 
         if ($tenant->isDirty($tenant->getTenantKeyName())) {
             $configuration['oldUsername'] = $tenant->getOriginal($tenant->getTenantKeyName());
+            $configuration['oldDatabase'] = $tenant->getOriginal($tenant->getTenantKeyName());
         }
 
         $configuration['username'] = $tenant->getTenantKey();
-        $configuration['database'] = $configuration['username'];
+        $configuration['database'] = $tenant->getTenantKey();
         $configuration['password'] = resolve(ProvidesPassword::class)->__invoke($tenant);
 
         return $configuration;


### PR DESCRIPTION
Fixes #212

This is a possible solution, but I'm not completely sure yet if this is the best solution.
It's sort of a breaking change; if people have custom logic and have not specified `oldDatabase`, but have specified `oldUsername`, than this is becoming an issue.