### PR TITLE
Feature: Allow users to disable the overwriting of the default connection and adjust hooks to perform properly on queues

### DIFF
--- a/src/Hooks/Migration/Hooks/MigratesHook.php
+++ b/src/Hooks/Migration/Hooks/MigratesHook.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Tenancy\Hooks\Migration\Hooks;
 
-use Illuminate\Database\Migrations\Migrator;
 use Tenancy\Affects\Connections\Contracts\ResolvesConnections;
 use Tenancy\Facades\Tenancy;
 use Tenancy\Hooks\Migration\Events\ConfigureMigrations;

--- a/src/Hooks/Migration/Hooks/MigratesHook.php
+++ b/src/Hooks/Migration/Hooks/MigratesHook.php
@@ -25,11 +25,7 @@ use Tenancy\Tenant\Events\Deleted;
 
 class MigratesHook extends ConfigurableHook
 {
-    public Migrator $migrator;
-
     public string $connection;
-
-    public ResolvesConnections $resolver;
 
     public $action;
 
@@ -39,11 +35,9 @@ class MigratesHook extends ConfigurableHook
 
     public function __construct()
     {
-        $this->migrator = resolve('migrator');
         $this->connection = Tenancy::getTenantConnectionName();
-        $this->resolver = resolve(ResolvesConnections::class);
 
-        $this->paths = $this->migrator->paths();
+        $this->paths = resolve('migrator')->paths();
     }
 
     public function for($event): static
@@ -60,17 +54,20 @@ class MigratesHook extends ConfigurableHook
     public function fire(): void
     {
         $db = resolve('db');
+        $migrator = resolve('migrator');
+        $resolver = resolve(ResolvesConnections::class);
+
         $default = $db->getDefaultConnection();
 
-        $this->resolver->__invoke($this->event->tenant, $this->connection);
-        $this->migrator->setConnection($this->connection);
+        $resolver->__invoke($this->event->tenant, $this->connection);
+        $migrator->setConnection($this->connection);
 
-        if (!$this->migrator->repositoryExists()) {
-            $this->migrator->getRepository()->createRepository();
+        if (!$migrator->repositoryExists()) {
+            $migrator->getRepository()->createRepository();
         }
-        call_user_func([$this->migrator, $this->action], $this->paths);
+        call_user_func([$migrator, $this->action], $this->paths);
 
-        $this->resolver->__invoke(null, $this->connection);
+        $resolver->__invoke(null, $this->connection);
         $db->setDefaultConnection($default);
     }
 }

--- a/src/Hooks/Migration/Hooks/SeedsHook.php
+++ b/src/Hooks/Migration/Hooks/SeedsHook.php
@@ -75,7 +75,7 @@ class SeedsHook extends ConfigurableHook
 
         $resolver->__invoke($this->event->tenant, $this->connection);
 
-        if($this->replaceDefaultConnection) {
+        if ($this->replaceDefaultConnection) {
             $db->setDefaultConnection($this->connection);
         }
 
@@ -89,7 +89,7 @@ class SeedsHook extends ConfigurableHook
 
         $resolver->__invoke(Tenancy::getTenant(), $this->connection);
 
-        if($this->replaceDefaultConnection) {
+        if ($this->replaceDefaultConnection) {
             $db->setDefaultConnection($default);
         }
 

--- a/src/Hooks/Migration/Hooks/SeedsHook.php
+++ b/src/Hooks/Migration/Hooks/SeedsHook.php
@@ -28,11 +28,11 @@ class SeedsHook extends ConfigurableHook
 {
     public string $connection;
 
-    public ResolvesConnections $resolver;
-
     public ?string $action = null;
 
     public int $priority = -40;
+
+    protected bool $replaceDefaultConnection = true;
 
     /** @var array|string[] */
     public array $seeds = [];
@@ -40,7 +40,6 @@ class SeedsHook extends ConfigurableHook
     public function __construct()
     {
         $this->connection = Tenancy::getTenantConnectionName();
-        $this->resolver = resolve(ResolvesConnections::class);
     }
 
     public function for($event): static
@@ -54,6 +53,13 @@ class SeedsHook extends ConfigurableHook
         return $this;
     }
 
+    public function withDefaultConnection(bool $replace = true): static
+    {
+        $this->replaceDefaultConnection = $replace;
+
+        return $this;
+    }
+
     public function fire(): void
     {
         if (empty($this->seeds)) {
@@ -61,13 +67,17 @@ class SeedsHook extends ConfigurableHook
         }
 
         $db = resolve('db');
+        $resolver = resolve(ResolvesConnections::class);
 
         $default = $db->getDefaultConnection();
 
         Model::unguard();
 
-        $this->resolver->__invoke($this->event->tenant, $this->connection);
-        $db->setDefaultConnection($this->connection);
+        $resolver->__invoke($this->event->tenant, $this->connection);
+
+        if($this->replaceDefaultConnection) {
+            $db->setDefaultConnection($this->connection);
+        }
 
         foreach ($this->seeds as $seed) {
             /** @var Seeder $seeder */
@@ -77,8 +87,11 @@ class SeedsHook extends ConfigurableHook
             $seeder();
         }
 
-        $this->resolver->__invoke(null, $this->connection);
-        $db->setDefaultConnection($default);
+        $resolver->__invoke(Tenancy::getTenant(), $this->connection);
+
+        if($this->replaceDefaultConnection) {
+            $db->setDefaultConnection($default);
+        }
 
         Model::reguard();
     }

--- a/tests/Hooks/Migration/Unit/ConfiguresSeedsTest.php
+++ b/tests/Hooks/Migration/Unit/ConfiguresSeedsTest.php
@@ -46,4 +46,23 @@ class ConfiguresSeedsTest extends ConfigureHookTestCase
             $this->hook->seeds
         );
     }
+
+    /**
+     * @dataProvider tenantEventsProvider
+     *
+     * @test */
+    public function it_can_decide_whether_to_replace_the_default($tenantEvent)
+    {
+        $this->events->listen($this->eventClass, function ($event) {
+            $event->hook->withDefaultConnection(false);
+        });
+
+        $this->hook->for(new $tenantEvent($this->mockTenant()));
+
+        $reflection = new \ReflectionClass($this->hook);
+
+        $this->assertFalse(
+            $reflection->getProperty('replaceDefaultConnection')->getValue($this->hook)
+        );
+    }
 }

--- a/tests/Hooks/Migration/Unit/ConfiguresSeedsTest.php
+++ b/tests/Hooks/Migration/Unit/ConfiguresSeedsTest.php
@@ -60,9 +60,11 @@ class ConfiguresSeedsTest extends ConfigureHookTestCase
         $this->hook->for(new $tenantEvent($this->mockTenant()));
 
         $reflection = new \ReflectionClass($this->hook);
+        $property = $reflection->getProperty('replaceDefaultConnection');
+        $property->setAccessible(true);
 
         $this->assertFalse(
-            $reflection->getProperty('replaceDefaultConnection')->getValue($this->hook)
+            $property->getValue($this->hook)
         );
     }
 }


### PR DESCRIPTION
An old friendly bug of ours returned:
Whenever you try to queue a Hook that has property dependencies that contain the Laravel application, it would result in Laravel not being able to queue it. Instead, we will resolve the dependencies we need at a later moment.